### PR TITLE
feat: add GUI applications category to Tools page

### DIFF
--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -383,6 +383,47 @@ const categories: Category[] = [
 			},
 		],
 	},
+	{
+		title: "GUIアプリケーション",
+		icon: "🖥️",
+		tools: [
+			{
+				name: "Visual Studio Code",
+				description: "マイクロソフトのコードエディタ",
+				url: "https://code.visualstudio.com/",
+			},
+			{
+				name: "Zed",
+				description: "高速で協調作業に最適化されたコードエディタ",
+				url: "https://zed.dev/",
+			},
+			{
+				name: "Ghostty",
+				description: "高速でGPUアクセラレーション対応のターミナル",
+				url: "https://ghostty.org/",
+			},
+			{
+				name: "Raycast",
+				description: "拡張可能なランチャー・生産性ツール",
+				url: "https://www.raycast.com/",
+			},
+			{
+				name: "Rancher Desktop",
+				description: "Kubernetes & コンテナ管理ツール",
+				url: "https://rancherdesktop.io/",
+			},
+			{
+				name: "Google Cloud CLI",
+				description: "Google Cloudのコマンドラインツール（GUI installer）",
+				url: "https://cloud.google.com/sdk/gcloud",
+			},
+			{
+				name: "Miniforge",
+				description: "conda/mamba Pythonディストリビューション",
+				url: "https://github.com/conda-forge/miniforge",
+			},
+		],
+	},
 ];
 ---
 

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -381,6 +381,11 @@ const categories: Category[] = [
 				description: "宣言的で再現可能なパッケージマネージャ",
 				url: "https://nixos.org/",
 			},
+			{
+				name: "Miniforge",
+				description: "conda/mamba Pythonディストリビューション",
+				url: "https://github.com/conda-forge/miniforge",
+			},
 		],
 	},
 	{
@@ -398,11 +403,6 @@ const categories: Category[] = [
 				url: "https://zed.dev/",
 			},
 			{
-				name: "Ghostty",
-				description: "高速でGPUアクセラレーション対応のターミナル",
-				url: "https://ghostty.org/",
-			},
-			{
 				name: "Raycast",
 				description: "拡張可能なランチャー・生産性ツール",
 				url: "https://www.raycast.com/",
@@ -411,16 +411,6 @@ const categories: Category[] = [
 				name: "Rancher Desktop",
 				description: "Kubernetes & コンテナ管理ツール",
 				url: "https://rancherdesktop.io/",
-			},
-			{
-				name: "Google Cloud CLI",
-				description: "Google Cloudのコマンドラインツール（GUI installer）",
-				url: "https://cloud.google.com/sdk/gcloud",
-			},
-			{
-				name: "Miniforge",
-				description: "conda/mamba Pythonディストリビューション",
-				url: "https://github.com/conda-forge/miniforge",
 			},
 		],
 	},


### PR DESCRIPTION
## Summary
- Toolsページに「GUIアプリケーション」カテゴリを追加
- Homebrew casksからインストールされているGUIアプリケーション7つを追加

## 追加したツール
- Visual Studio Code - マイクロソフトのコードエディタ
- Zed - 高速で協調作業に最適化されたコードエディタ
- Ghostty - 高速でGPUアクセラレーション対応のターミナル
- Raycast - 拡張可能なランチャー・生産性ツール
- Rancher Desktop - Kubernetes & コンテナ管理ツール
- Google Cloud CLI - Google Cloudのコマンドラインツール（GUI installer）
- Miniforge - conda/mamba Pythonディストリビューション

## Test plan
- [x] `pnpm build` が成功することを確認
- [x] ビルド出力に11ページが含まれることを確認
- [ ] ローカルでページの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)