### PR TITLE
feat: enhance 404 page and add Wrangler configuration

### DIFF
--- a/src/__tests__/rss-loader.test.ts
+++ b/src/__tests__/rss-loader.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import Parser from "rss-parser";
+import { describe, expect, it } from "vitest";
 
 describe("RSS Loaders", () => {
 	describe("Zenn RSS Feed", () => {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,7 +1,7 @@
 ---
 import "../styles/global.css";
-import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
+import Header from "../components/Header.astro";
 
 interface Props {
 	title?: string;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,15 +5,13 @@ import Layout from "../layouts/Layout.astro";
 <Layout
 	title="404 - ページが見つかりません | Portfolio"
 	description="お探しのページは見つかりませんでした。"
-	noHeader={true}
-	noFooter={true}
 >
 	<main class="flex min-h-screen items-center justify-center px-6">
 		<div class="text-center">
 			<!-- 404 大きな数字 -->
 			<div class="mb-8">
 				<h1
-					class="bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-6xl font-bold text-transparent sm:text-9xl"
+					class="bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-6xl font-bold text-transparent sm:text-8xl md:text-9xl"
 				>
 					404
 				</h1>
@@ -41,6 +39,7 @@ import Layout from "../layouts/Layout.astro";
 					type="button"
 					id="history-back-button"
 					class="rounded-lg border-2 border-gray-300 px-6 py-3 font-semibold text-gray-700 transition-all hover:border-gray-400 hover:bg-gray-50"
+					aria-label="前のページに戻る"
 				>
 					前のページへ
 				</button>
@@ -57,14 +56,17 @@ import Layout from "../layouts/Layout.astro";
 <script>
 	const backButton = document.getElementById("history-back-button");
 	backButton?.addEventListener("click", () => {
-		// Check if there's a referrer from the same origin
-		if (
-			document.referrer &&
-			new URL(document.referrer).origin === window.location.origin
-		) {
-			window.history.back();
-		} else {
-			// If no referrer or different origin, navigate to home page
+		try {
+			if (
+				document.referrer &&
+				new URL(document.referrer).origin === window.location.origin
+			) {
+				window.history.back();
+			} else {
+				window.location.href = "/";
+			}
+		} catch (e) {
+			console.error("Failed to go back:", e);
 			window.location.href = "/";
 		}
 	});

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -8,16 +8,47 @@ import Layout from "../layouts/Layout.astro";
 	noHeader={true}
 	noFooter={true}
 >
-	<main class="flex min-h-screen flex-col items-center justify-center px-4">
+	<main class="flex min-h-screen items-center justify-center px-6">
 		<div class="text-center">
-			<h1 class="mb-4 text-6xl font-bold">404</h1>
-			<p class="mb-8 text-xl">ページが見つかりませんでした</p>
-			<a
-				href="/"
-				class="inline-block rounded-lg bg-gray-900 px-6 py-3 text-white transition-colors hover:bg-gray-700"
-			>
-				トップページへ戻る
-			</a>
+			<!-- 404 大きな数字 -->
+			<div class="mb-8">
+				<h1
+					class="bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-9xl font-bold text-transparent"
+				>
+					404
+				</h1>
+			</div>
+
+			<!-- エラーメッセージ -->
+			<div class="mb-8">
+				<h2 class="mb-4 text-3xl font-bold text-gray-800">
+					ページが見つかりません
+				</h2>
+				<p class="mx-auto max-w-md text-gray-600">
+					お探しのページは存在しないか、移動または削除された可能性があります。
+				</p>
+			</div>
+
+			<!-- アクションボタン -->
+			<div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
+				<a
+					href="/"
+					class="rounded-lg bg-gradient-to-r from-purple-600 to-pink-600 px-6 py-3 font-semibold text-white shadow-lg transition-all hover:scale-105 hover:shadow-xl"
+				>
+					ホームに戻る
+				</a>
+				<button
+					onclick="history.back()"
+					class="rounded-lg border-2 border-gray-300 px-6 py-3 font-semibold text-gray-700 transition-all hover:border-gray-400 hover:bg-gray-50"
+				>
+					前のページへ
+				</button>
+			</div>
+
+			<!-- 装飾的な要素 -->
+			<div class="mt-16 text-6xl opacity-20">
+				🔍
+			</div>
 		</div>
 	</main>
 </Layout>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -13,7 +13,7 @@ import Layout from "../layouts/Layout.astro";
 			<!-- 404 大きな数字 -->
 			<div class="mb-8">
 				<h1
-					class="bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-9xl font-bold text-transparent"
+					class="bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-6xl font-bold text-transparent sm:text-9xl"
 				>
 					404
 				</h1>
@@ -57,11 +57,14 @@ import Layout from "../layouts/Layout.astro";
 <script>
 	const backButton = document.getElementById("history-back-button");
 	backButton?.addEventListener("click", () => {
-		// Check if there's history to go back to
-		if (window.history.length > 1) {
+		// Check if there's a referrer from the same origin
+		if (
+			document.referrer &&
+			new URL(document.referrer).origin === window.location.origin
+		) {
 			window.history.back();
 		} else {
-			// If no history, navigate to home page
+			// If no referrer or different origin, navigate to home page
 			window.location.href = "/";
 		}
 	});

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -46,7 +46,7 @@ import Layout from "../layouts/Layout.astro";
 			</div>
 
 			<!-- 装飾的な要素 -->
-			<div class="mt-16 text-6xl opacity-20">
+			<div class="mt-16 text-6xl opacity-20" aria-hidden="true">
 				🔍
 			</div>
 		</div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -38,7 +38,8 @@ import Layout from "../layouts/Layout.astro";
 					ホームに戻る
 				</a>
 				<button
-					onclick="history.back()"
+					type="button"
+					id="history-back-button"
 					class="rounded-lg border-2 border-gray-300 px-6 py-3 font-semibold text-gray-700 transition-all hover:border-gray-400 hover:bg-gray-50"
 				>
 					前のページへ
@@ -52,3 +53,16 @@ import Layout from "../layouts/Layout.astro";
 		</div>
 	</main>
 </Layout>
+
+<script>
+	const backButton = document.getElementById("history-back-button");
+	backButton?.addEventListener("click", () => {
+		// Check if there's history to go back to
+		if (window.history.length > 1) {
+			window.history.back();
+		} else {
+			// If no history, navigate to home page
+			window.location.href = "/";
+		}
+	});
+</script>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from "../layouts/Layout.astro";
 import { getCollection, render } from "astro:content";
+import Layout from "../layouts/Layout.astro";
 
 const aboutEntries = await getCollection("about");
 const aboutContent = aboutEntries[0];

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -1,6 +1,6 @@
 ---
-import Layout from "../../layouts/Layout.astro";
 import { getCollection, render } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
 
 export async function getStaticPaths() {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,11 +1,11 @@
 ---
-import Layout from "../../layouts/Layout.astro";
 import { getCollection } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
 
 const blogPosts = await getCollection("blog");
 const sortedPosts = blogPosts.sort(
-	(a, b) => b.data.date.getTime() - a.data.date.getTime()
+	(a, b) => b.data.date.getTime() - a.data.date.getTime(),
 );
 ---
 

--- a/src/pages/links.astro
+++ b/src/pages/links.astro
@@ -1,16 +1,17 @@
 ---
-import Layout from "../layouts/Layout.astro";
 import { getCollection } from "astro:content";
-import { formatDate } from "../utils/date";
 import SnsLinks from "../components/SnsLinks.astro";
+import Layout from "../layouts/Layout.astro";
+import { formatDate } from "../utils/date";
 
 // すべてのフィードを取得
-const [zennPosts, notePosts, podcastEpisodes, qiitaArticles] = await Promise.all([
-	getCollection("zenn"),
-	getCollection("note"),
-	getCollection("podcast"),
-	getCollection("qiita"),
-]);
+const [zennPosts, notePosts, podcastEpisodes, qiitaArticles] =
+	await Promise.all([
+		getCollection("zenn"),
+		getCollection("note"),
+		getCollection("podcast"),
+		getCollection("qiita"),
+	]);
 
 // 統合型定義
 type FeedItem = {

--- a/src/pages/qiita.astro
+++ b/src/pages/qiita.astro
@@ -1,11 +1,11 @@
 ---
-import Layout from "../layouts/Layout.astro";
 import { getCollection } from "astro:content";
+import Layout from "../layouts/Layout.astro";
 import { formatDate } from "../utils/date";
 
 const qiitaArticles = await getCollection("qiita");
 const sortedArticles = qiitaArticles.sort(
-	(a, b) => b.data.createdAt.getTime() - a.data.createdAt.getTime()
+	(a, b) => b.data.createdAt.getTime() - a.data.createdAt.getTime(),
 );
 ---
 

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -1,12 +1,12 @@
 ---
-import Layout from "../layouts/Layout.astro";
 import { getCollection } from "astro:content";
+import Layout from "../layouts/Layout.astro";
 import { formatDate } from "../utils/date";
 
 const talksEntries = await getCollection("talks");
 const talksData = talksEntries[0]?.data.items || [];
 const sortedTalks = talksData.sort(
-	(a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+	(a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
 );
 ---
 

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -20,7 +20,8 @@ const categories: Category[] = [
 		tools: [
 			{
 				name: "Fish",
-				description: "シンタックスハイライトと強力な補完機能を持つモダンなシェル",
+				description:
+					"シンタックスハイライトと強力な補完機能を持つモダンなシェル",
 				url: "https://fishshell.com/",
 			},
 			{
@@ -139,7 +140,8 @@ const categories: Category[] = [
 		tools: [
 			{
 				name: "bottom",
-				description: "カスタマイズ可能なクロスプラットフォームのシステム監視ツール",
+				description:
+					"カスタマイズ可能なクロスプラットフォームのシステム監視ツール",
 				url: "https://github.com/ClementTsang/bottom",
 			},
 			{

--- a/src/pages/works/[id].astro
+++ b/src/pages/works/[id].astro
@@ -1,7 +1,7 @@
 ---
-import Layout from "../../layouts/Layout.astro";
-import { getCollection, render } from "astro:content";
 import { Image } from "astro:assets";
+import { getCollection, render } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
 
 export async function getStaticPaths() {

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -1,11 +1,11 @@
 ---
-import Layout from "../../layouts/Layout.astro";
-import { getCollection } from "astro:content";
 import { Image } from "astro:assets";
+import { getCollection } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
 
 const works = await getCollection("works");
 const sortedWorks = works.sort(
-	(a, b) => b.data.startDate.getTime() - a.data.startDate.getTime()
+	(a, b) => b.data.startDate.getTime() - a.data.startDate.getTime(),
 );
 ---
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,10 +2,7 @@
   "name": "me",
   "compatibility_date": "2026-01-01",
   "assets": {
-    "directory": "./dist",
-    "binding": "ASSETS",
-    "html_handling": "auto-trailing-slash",
-    "not_found_handling": "404-page"
+    "directory": "./dist"
   },
   "observability": {
     "enabled": true

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,12 @@
   "name": "me",
   "compatibility_date": "2026-01-01",
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "html_handling": "auto-trailing-slash",
+    "not_found_handling": "404-page"
+  },
+  "observability": {
+    "enabled": true
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,10 @@
   "name": "me",
   "compatibility_date": "2026-01-01",
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "html_handling": "auto-trailing-slash",
+    "not_found_handling": "404-page"
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
## Summary
- 404ページのデザインを大幅改善
- Wrangler設定に観測性とアセット処理を追加

## 404ページの改善
- **グラデーション表示**: purple-pink グラデーションで目立つ404表示
- **詳細なメッセージ**: ユーザーフレンドリーなエラー説明
- **2つのアクションボタン**: 
  - ホームに戻る（プライマリボタン）
  - 前のページへ（セカンダリボタン）
- **レスポンシブデザイン**: モバイル対応のフレキシブルレイアウト
- **装飾要素**: 虫眼鏡アイコンでビジュアル強化

## Wrangler設定の追加
- `observability.enabled: true` - ログ・監視機能
- `assets.binding: "ASSETS"` - アセットバインディング
- `assets.html_handling: "auto-trailing-slash"` - URL正規化
- `assets.not_found_handling: "404-page"` - 404ページ自動処理

## Test plan
- [x] `pnpm build` が成功することを確認
- [x] ビルド出力に `/404.html` が含まれることを確認
- [ ] ローカルで404ページの表示を確認
- [ ] Cloudflare Workersにデプロイ後、404動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)