### PR TITLE
Improve SEO metadata

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -55,11 +55,11 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		<meta property="og:locale" content="ja_JP" />
 
 		<!-- Twitter -->
-		<meta property="twitter:card" content="summary_large_image" />
-		<meta property="twitter:url" content={canonicalURL} />
-		<meta property="twitter:title" content={title} />
-		<meta property="twitter:description" content={description} />
-		<meta property="twitter:image" content={ogImageURL} />
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:url" content={canonicalURL} />
+		<meta name="twitter:title" content={title} />
+		<meta name="twitter:description" content={description} />
+		<meta name="twitter:image" content={ogImageURL} />
 		<meta name="twitter:image:alt" content={ogImageAlt} />
 
 		<!-- 構造化データ (JSON-LD) -->

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,7 +7,9 @@ interface Props {
 	title?: string;
 	description?: string;
 	ogImage?: string;
+	ogImageAlt?: string;
 	ogSiteName?: string;
+	ogType?: "website" | "article" | "book";
 	noHeader?: boolean;
 	noFooter?: boolean;
 }
@@ -16,7 +18,9 @@ const {
 	title = "Portfolio",
 	description = "個人ポートフォリオサイト",
 	ogImage = "/og-image.png",
+	ogImageAlt = title,
 	ogSiteName = "Portfolio",
+	ogType = "website",
 	noHeader = false,
 	noFooter = false,
 } = Astro.props;
@@ -41,11 +45,12 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		<link rel="canonical" href={canonicalURL} />
 
 		<!-- Open Graph / Facebook -->
-		<meta property="og:type" content="website" />
+		<meta property="og:type" content={ogType} />
 		<meta property="og:url" content={canonicalURL} />
 		<meta property="og:title" content={title} />
 		<meta property="og:description" content={description} />
 		<meta property="og:image" content={ogImageURL} />
+		<meta property="og:image:alt" content={ogImageAlt} />
 		<meta property="og:site_name" content={ogSiteName} />
 		<meta property="og:locale" content="ja_JP" />
 
@@ -55,6 +60,7 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		<meta property="twitter:title" content={title} />
 		<meta property="twitter:description" content={description} />
 		<meta property="twitter:image" content={ogImageURL} />
+		<meta name="twitter:image:alt" content={ogImageAlt} />
 
 		<!-- 構造化データ (JSON-LD) -->
 		<script type="application/ld+json">

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -51,7 +51,10 @@ const blogSchema = {
 		{post.data.updatedDate && (
 			<meta property="article:modified_time" content={modifiedTime} />
 		)}
-		<script type="application/ld+json" set:html={JSON.stringify(blogSchema)} />
+		<script
+			type="application/ld+json"
+			set:html={JSON.stringify(blogSchema).replace(/</g, "\\u003c")}
+		/>
 	</Fragment>
 	<main class="mx-auto max-w-4xl px-6 py-12">
 		<Breadcrumb

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -46,6 +46,7 @@ const blogSchema = {
 	ogImageAlt={post.data.title}
 >
 	<Fragment slot="head">
+		<meta property="article:author" content="Takumi Abe" />
 		<meta property="article:published_time" content={publishedTime} />
 		{post.data.updatedDate && (
 			<meta property="article:modified_time" content={modifiedTime} />

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -51,9 +51,7 @@ const blogSchema = {
 		{post.data.updatedDate && (
 			<meta property="article:modified_time" content={modifiedTime} />
 		)}
-		<script type="application/ld+json">
-			{JSON.stringify(blogSchema)}
-		</script>
+		<script type="application/ld+json" set:html={JSON.stringify(blogSchema)} />
 	</Fragment>
 	<main class="mx-auto max-w-4xl px-6 py-12">
 		<Breadcrumb

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -14,12 +14,46 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 const { Content } = await render(post);
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const publishedTime = post.data.date.toISOString();
+const modifiedTime = post.data.updatedDate
+	? post.data.updatedDate.toISOString()
+	: publishedTime;
+const ogImageURL = new URL("/og-image.png", Astro.site);
+const blogSchema = {
+	"@context": "https://schema.org",
+	"@type": "BlogPosting",
+	headline: post.data.title,
+	description: post.data.excerpt,
+	datePublished: publishedTime,
+	dateModified: modifiedTime,
+	author: {
+		"@type": "Person",
+		name: "Takumi Abe",
+		url: Astro.site.href,
+	},
+	image: ogImageURL.href,
+	mainEntityOfPage: canonicalURL.href,
+	inLanguage: "ja",
+};
 ---
 
 <Layout
 	title={`${post.data.title} | Blog | Portfolio`}
 	description={post.data.excerpt}
+	ogType="article"
+	ogImage={ogImageURL.href}
+	ogImageAlt={post.data.title}
 >
+	<Fragment slot="head">
+		<meta property="article:published_time" content={publishedTime} />
+		{post.data.updatedDate && (
+			<meta property="article:modified_time" content={modifiedTime} />
+		)}
+		<script type="application/ld+json">
+			{JSON.stringify(blogSchema)}
+		</script>
+	</Fragment>
 	<main class="mx-auto max-w-4xl px-6 py-12">
 		<Breadcrumb
 			items={[

--- a/src/pages/bookshelf/[id].astro
+++ b/src/pages/bookshelf/[id].astro
@@ -17,6 +17,11 @@ const { book } = Astro.props;
 const { Content } = await render(book);
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const ogImageURL = new URL(book.data.coverImage.src, Astro.site);
+const tags = book.data.tags
+	? Array.isArray(book.data.tags)
+		? book.data.tags
+		: [book.data.tags]
+	: [];
 const bookSchema = {
 	"@context": "https://schema.org",
 	"@type": "Book",
@@ -27,9 +32,7 @@ const bookSchema = {
 	},
 	description: book.data.excerpt,
 	image: ogImageURL.href,
-	genre: Array.isArray(book.data.tags)
-		? book.data.tags.join(", ")
-		: book.data.tags,
+	genre: tags.join(", "),
 	url: canonicalURL.href,
 	inLanguage: "ja",
 };
@@ -44,8 +47,11 @@ const bookSchema = {
 >
 	<Fragment slot="head">
 		<meta property="book:author" content={book.data.author} />
-		{book.data.tags.map((tag) => <meta property="book:tag" content={tag} />)}
-		<script type="application/ld+json" set:html={JSON.stringify(bookSchema)} />
+		{tags.map((tag) => <meta property="book:tag" content={tag} />)}
+		<script
+			type="application/ld+json"
+			set:html={JSON.stringify(bookSchema).replace(/</g, "\\u003c")}
+		/>
 	</Fragment>
 	<main class="mx-auto max-w-4xl px-6 py-12">
 		<div class="mb-8">
@@ -80,7 +86,7 @@ const bookSchema = {
 				)}
 			</div>
 			<div class="flex flex-wrap gap-2">
-				{book.data.tags.map((tag) => (
+				{tags.map((tag) => (
 					<span class="rounded-full bg-gray-100 px-3 py-1 text-xs">
 						{tag}
 					</span>

--- a/src/pages/bookshelf/[id].astro
+++ b/src/pages/bookshelf/[id].astro
@@ -27,7 +27,9 @@ const bookSchema = {
 	},
 	description: book.data.excerpt,
 	image: ogImageURL.href,
-	genre: book.data.tags,
+	genre: Array.isArray(book.data.tags)
+		? book.data.tags.join(", ")
+		: book.data.tags,
 	url: canonicalURL.href,
 	inLanguage: "ja",
 };
@@ -37,10 +39,12 @@ const bookSchema = {
 	title={`${book.data.title} | Bookshelf | Portfolio`}
 	description={book.data.excerpt}
 	ogType="book"
-	ogImage={book.data.coverImage.src}
+	ogImage={ogImageURL.href}
 	ogImageAlt={`${book.data.title} cover`}
 >
 	<Fragment slot="head">
+		<meta property="book:author" content={book.data.author} />
+		{book.data.tags.map((tag) => <meta property="book:tag" content={tag} />)}
 		<script type="application/ld+json">
 			{JSON.stringify(bookSchema)}
 		</script>

--- a/src/pages/bookshelf/[id].astro
+++ b/src/pages/bookshelf/[id].astro
@@ -15,12 +15,36 @@ export async function getStaticPaths() {
 
 const { book } = Astro.props;
 const { Content } = await render(book);
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const ogImageURL = new URL(book.data.coverImage.src, Astro.site);
+const bookSchema = {
+	"@context": "https://schema.org",
+	"@type": "Book",
+	name: book.data.title,
+	author: {
+		"@type": "Person",
+		name: book.data.author,
+	},
+	description: book.data.excerpt,
+	image: ogImageURL.href,
+	genre: book.data.tags,
+	url: canonicalURL.href,
+	inLanguage: "ja",
+};
 ---
 
 <Layout
 	title={`${book.data.title} | Bookshelf | Portfolio`}
 	description={book.data.excerpt}
+	ogType="book"
+	ogImage={book.data.coverImage.src}
+	ogImageAlt={`${book.data.title} cover`}
 >
+	<Fragment slot="head">
+		<script type="application/ld+json">
+			{JSON.stringify(bookSchema)}
+		</script>
+	</Fragment>
 	<main class="mx-auto max-w-4xl px-6 py-12">
 		<div class="mb-8">
 			<a

--- a/src/pages/bookshelf/[id].astro
+++ b/src/pages/bookshelf/[id].astro
@@ -45,9 +45,7 @@ const bookSchema = {
 	<Fragment slot="head">
 		<meta property="book:author" content={book.data.author} />
 		{book.data.tags.map((tag) => <meta property="book:tag" content={tag} />)}
-		<script type="application/ld+json">
-			{JSON.stringify(bookSchema)}
-		</script>
+		<script type="application/ld+json" set:html={JSON.stringify(bookSchema)} />
 	</Fragment>
 	<main class="mx-auto max-w-4xl px-6 py-12">
 		<div class="mb-8">

--- a/src/pages/works/[id].astro
+++ b/src/pages/works/[id].astro
@@ -53,7 +53,10 @@ const workSchema = {
 		{work.data.endDate && (
 			<meta property="article:modified_time" content={modifiedTime} />
 		)}
-		<script type="application/ld+json" set:html={JSON.stringify(workSchema)} />
+		<script
+			type="application/ld+json"
+			set:html={JSON.stringify(workSchema).replace(/</g, "\\u003c")}
+		/>
 	</Fragment>
 	<main class="mx-auto max-w-4xl px-6 py-12">
 		<Breadcrumb

--- a/src/pages/works/[id].astro
+++ b/src/pages/works/[id].astro
@@ -15,12 +15,43 @@ export async function getStaticPaths() {
 
 const { work } = Astro.props;
 const { Content } = await render(work);
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const ogImageURL = new URL(work.data.coverImage.src, Astro.site);
+const createdTime = work.data.startDate.toISOString();
+const modifiedTime = work.data.endDate
+	? work.data.endDate.toISOString()
+	: createdTime;
+const workSchema = {
+	"@context": "https://schema.org",
+	"@type": "CreativeWork",
+	name: work.data.title,
+	description: work.data.excerpt,
+	image: ogImageURL.href,
+	keywords: work.data.keywords.join(", "),
+	dateCreated: createdTime,
+	dateModified: modifiedTime,
+	author: {
+		"@type": "Person",
+		name: "Takumi Abe",
+		url: Astro.site.href,
+	},
+	url: canonicalURL.href,
+	inLanguage: "ja",
+};
 ---
 
 <Layout
 	title={`${work.data.title} | Works | Portfolio`}
 	description={work.data.excerpt}
+	ogType="article"
+	ogImage={work.data.coverImage.src}
+	ogImageAlt={work.data.title}
 >
+	<Fragment slot="head">
+		<script type="application/ld+json">
+			{JSON.stringify(workSchema)}
+		</script>
+	</Fragment>
 	<main class="mx-auto max-w-4xl px-6 py-12">
 		<Breadcrumb
 			items={[

--- a/src/pages/works/[id].astro
+++ b/src/pages/works/[id].astro
@@ -44,10 +44,15 @@ const workSchema = {
 	title={`${work.data.title} | Works | Portfolio`}
 	description={work.data.excerpt}
 	ogType="article"
-	ogImage={work.data.coverImage.src}
+	ogImage={ogImageURL.href}
 	ogImageAlt={work.data.title}
 >
 	<Fragment slot="head">
+		<meta property="article:author" content="Takumi Abe" />
+		<meta property="article:published_time" content={createdTime} />
+		{work.data.endDate && (
+			<meta property="article:modified_time" content={modifiedTime} />
+		)}
 		<script type="application/ld+json">
 			{JSON.stringify(workSchema)}
 		</script>

--- a/src/pages/works/[id].astro
+++ b/src/pages/works/[id].astro
@@ -53,9 +53,7 @@ const workSchema = {
 		{work.data.endDate && (
 			<meta property="article:modified_time" content={modifiedTime} />
 		)}
-		<script type="application/ld+json">
-			{JSON.stringify(workSchema)}
-		</script>
+		<script type="application/ld+json" set:html={JSON.stringify(workSchema)} />
 	</Fragment>
 	<main class="mx-auto max-w-4xl px-6 py-12">
 		<Breadcrumb


### PR DESCRIPTION
## 概要

SEOメタデータを強化し、検索エンジンとソーシャルメディアでの表示を改善しました。

### 主な変更

- **Open GraphとTwitterカードの拡張**
  - `og:image:alt` と `twitter:image:alt` のサポート追加
  - 動的な `og:type` プロパティの実装

- **構造化データ（JSON-LD）の実装**
  - ブログ投稿: `BlogPosting` スキーマ
  - 作品: `CreativeWork` スキーマ
  - 書籍: `Book` スキーマ

- **Articleメタデータの追加**
  - `article:author` - 著者情報
  - `article:published_time` - 公開日時
  - `article:modified_time` - 更新日時（該当する場合）

- **Bookメタデータの追加**
  - `book:author` - 著者情報
  - `book:tag` - タグ情報

### 対応したレビューコメント

#### Gemini Code Assist
- ✅ 書籍ページに `book:author` と `book:tag` メタタグを追加
- ✅ 作品ページに `article:*` メタタグを追加

#### GitHub Copilot
- ✅ `ogImage` プロパティを絶対URLに統一
- ✅ Book スキーマの `genre` を文字列形式に変換
- ✅ ブログと作品ページに `article:author` を追加

## テスト方針

- [ ] ブログ、作品、書籍の各詳細ページが正しく表示されることを確認
- [ ] Open Graphメタタグが適切に設定されていることを確認
- [ ] JSON-LD構造化データが有効であることを確認
- [ ] ソーシャルメディアシェア時のプレビューが正しく表示されることを確認

## 関連情報

検索エンジンとソーシャルメディアプラットフォームがコンテンツをより適切に理解し、リッチスニペットとして表示できるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable Open Graph options: image alt text and selectable content type (website/article/book) for richer social previews
  * Added image alt text for Twitter cards to improve accessibility on social shares
  * Page-level canonical URLs and enhanced social metadata for blog, book, and work pages
  * JSON-LD structured data added for posts, books, and creative works to boost search visibility and rich results

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->