### PR TITLE
feat: add missing brew cask applications to tools page

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,188 +4,188 @@ import Parser from "rss-parser";
 
 // Aboutコレクション
 const about = defineCollection({
-  loader: glob({ pattern: "**/*.md", base: "./src/content/about" }),
-  schema: ({ image }) =>
-    z.object({
-      title: z.string(),
-      summary: z.array(z.string()),
-      image: image().optional(),
-      heading: z.string().optional(),
-    }),
+	loader: glob({ pattern: "**/*.md", base: "./src/content/about" }),
+	schema: ({ image }) =>
+		z.object({
+			title: z.string(),
+			summary: z.array(z.string()),
+			image: image().optional(),
+			heading: z.string().optional(),
+		}),
 });
 
 // Worksコレクション（ポートフォリオ作品）
 const works = defineCollection({
-  loader: glob({ pattern: "**/*.md", base: "./src/content/works" }),
-  schema: ({ image }) =>
-    z.object({
-      title: z.string(),
-      coverImage: image(),
-      keywords: z.array(z.string()),
-      startDate: z.coerce.date(),
-      endDate: z.coerce.date().optional(),
-      excerpt: z.string(),
-    }),
+	loader: glob({ pattern: "**/*.md", base: "./src/content/works" }),
+	schema: ({ image }) =>
+		z.object({
+			title: z.string(),
+			coverImage: image(),
+			keywords: z.array(z.string()),
+			startDate: z.coerce.date(),
+			endDate: z.coerce.date().optional(),
+			excerpt: z.string(),
+		}),
 });
 
 // Booksコレクション（読書記録）
 const books = defineCollection({
-  loader: glob({ pattern: "**/*.md", base: "./src/content/books" }),
-  schema: ({ image }) =>
-    z.object({
-      title: z.string(),
-      author: z.string(),
-      coverImage: image(),
-      status: z.enum(["read", "reading", "stacked"]),
-      finishedDate: z.coerce.date().optional(),
-      rating: z.number().min(1).max(5).optional(),
-      category: z.string().optional(),
-      tags: z.array(z.string()),
-      excerpt: z.string(),
-    }),
+	loader: glob({ pattern: "**/*.md", base: "./src/content/books" }),
+	schema: ({ image }) =>
+		z.object({
+			title: z.string(),
+			author: z.string(),
+			coverImage: image(),
+			status: z.enum(["read", "reading", "stacked"]),
+			finishedDate: z.coerce.date().optional(),
+			rating: z.number().min(1).max(5).optional(),
+			category: z.string().optional(),
+			tags: z.array(z.string()),
+			excerpt: z.string(),
+		}),
 });
 
 // Blogコレクション（MD/MDX対応）
 const blog = defineCollection({
-  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/blog" }),
-  schema: z.object({
-    title: z.string(),
-    date: z.coerce.date(),
-    updatedDate: z.coerce.date().optional(),
-    excerpt: z.string(),
-    tags: z.array(z.string()).optional(),
-  }),
+	loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/blog" }),
+	schema: z.object({
+		title: z.string(),
+		date: z.coerce.date(),
+		updatedDate: z.coerce.date().optional(),
+		excerpt: z.string(),
+		tags: z.array(z.string()).optional(),
+	}),
 });
 
 // Talksコレクション（登壇情報）
 const talks = defineCollection({
-  loader: glob({ pattern: "**/*.json", base: "./src/content/talks" }),
-  schema: z.object({
-    items: z.array(
-      z.object({
-        id: z.string(),
-        url: z.string().url().optional(),
-        date: z.coerce.date(),
-        title: z.string(),
-      }),
-    ),
-  }),
+	loader: glob({ pattern: "**/*.json", base: "./src/content/talks" }),
+	schema: z.object({
+		items: z.array(
+			z.object({
+				id: z.string(),
+				url: z.string().url().optional(),
+				date: z.coerce.date(),
+				title: z.string(),
+			}),
+		),
+	}),
 });
 
 // Zenn記事コレクション（RSS）
 const zenn = defineCollection({
-  loader: async () => {
-    try {
-      const parser = new Parser();
-      const feed = await parser.parseURL("https://zenn.dev/ta93abe/feed");
+	loader: async () => {
+		try {
+			const parser = new Parser();
+			const feed = await parser.parseURL("https://zenn.dev/ta93abe/feed");
 
-      if (!feed.items) {
-        return [];
-      }
+			if (!feed.items) {
+				return [];
+			}
 
-      return feed.items
-        .filter((item) => item.title && item.link)
-        .map((item, index) => ({
-          id: `zenn-${index}`,
-          title: item.title!,
-          url: item.link!,
-          publishedAt: new Date(item.pubDate!),
-          excerpt: item.contentSnippet || item.content || "",
-          source: "Zenn" as const,
-        }));
-    } catch (error) {
-      console.error("Error fetching Zenn feed:", error);
-      return [];
-    }
-  },
-  schema: z.object({
-    title: z.string(),
-    url: z.string().url(),
-    publishedAt: z.date(),
-    excerpt: z.string(),
-    source: z.literal("Zenn"),
-  }),
+			return feed.items
+				.filter((item) => item.title && item.link)
+				.map((item, index) => ({
+					id: `zenn-${index}`,
+					title: item.title!,
+					url: item.link!,
+					publishedAt: new Date(item.pubDate!),
+					excerpt: item.contentSnippet || item.content || "",
+					source: "Zenn" as const,
+				}));
+		} catch (error) {
+			console.error("Error fetching Zenn feed:", error);
+			return [];
+		}
+	},
+	schema: z.object({
+		title: z.string(),
+		url: z.string().url(),
+		publishedAt: z.date(),
+		excerpt: z.string(),
+		source: z.literal("Zenn"),
+	}),
 });
 
 // Note記事コレクション（RSS）
 const note = defineCollection({
-  loader: async () => {
-    try {
-      const parser = new Parser();
-      const feed = await parser.parseURL("https://note.com/ta93abe/rss");
+	loader: async () => {
+		try {
+			const parser = new Parser();
+			const feed = await parser.parseURL("https://note.com/ta93abe/rss");
 
-      if (!feed.items) {
-        return [];
-      }
+			if (!feed.items) {
+				return [];
+			}
 
-      return feed.items
-        .filter((item) => item.title && item.link)
-        .map((item, index) => ({
-          id: `note-${index}`,
-          title: item.title!,
-          url: item.link!,
-          publishedAt: new Date(item.pubDate!),
-          excerpt: item.contentSnippet || item.content || "",
-          source: "Note" as const,
-        }));
-    } catch (error) {
-      console.error("Error fetching Note RSS:", error);
-      return [];
-    }
-  },
-  schema: z.object({
-    title: z.string(),
-    url: z.string().url(),
-    publishedAt: z.date(),
-    excerpt: z.string(),
-    source: z.literal("Note"),
-  }),
+			return feed.items
+				.filter((item) => item.title && item.link)
+				.map((item, index) => ({
+					id: `note-${index}`,
+					title: item.title!,
+					url: item.link!,
+					publishedAt: new Date(item.pubDate!),
+					excerpt: item.contentSnippet || item.content || "",
+					source: "Note" as const,
+				}));
+		} catch (error) {
+			console.error("Error fetching Note RSS:", error);
+			return [];
+		}
+	},
+	schema: z.object({
+		title: z.string(),
+		url: z.string().url(),
+		publishedAt: z.date(),
+		excerpt: z.string(),
+		source: z.literal("Note"),
+	}),
 });
 
 // ポッドキャストコレクション（RSS）
 const podcast = defineCollection({
-  loader: async () => {
-    try {
-      const parser = new Parser();
-      const feed = await parser.parseURL(
-        "https://anchor.fm/s/4dd661e8/podcast/rss",
-      );
+	loader: async () => {
+		try {
+			const parser = new Parser();
+			const feed = await parser.parseURL(
+				"https://anchor.fm/s/4dd661e8/podcast/rss",
+			);
 
-      if (!feed.items) {
-        return [];
-      }
+			if (!feed.items) {
+				return [];
+			}
 
-      return feed.items
-        .filter((item) => item.title && item.link)
-        .map((item, index) => ({
-          id: `podcast-${index}`,
-          title: item.title!,
-          url: item.link!,
-          publishedAt: new Date(item.pubDate!),
-          excerpt: item.contentSnippet || item.content || "",
-          source: "Podcast" as const,
-        }));
-    } catch (error) {
-      console.error("Error fetching Podcast RSS:", error);
-      return [];
-    }
-  },
-  schema: z.object({
-    title: z.string(),
-    url: z.string().url(),
-    publishedAt: z.date(),
-    excerpt: z.string(),
-    source: z.literal("Podcast"),
-  }),
+			return feed.items
+				.filter((item) => item.title && item.link)
+				.map((item, index) => ({
+					id: `podcast-${index}`,
+					title: item.title!,
+					url: item.link!,
+					publishedAt: new Date(item.pubDate!),
+					excerpt: item.contentSnippet || item.content || "",
+					source: "Podcast" as const,
+				}));
+		} catch (error) {
+			console.error("Error fetching Podcast RSS:", error);
+			return [];
+		}
+	},
+	schema: z.object({
+		title: z.string(),
+		url: z.string().url(),
+		publishedAt: z.date(),
+		excerpt: z.string(),
+		source: z.literal("Podcast"),
+	}),
 });
 
 export const collections = {
-  about,
-  works,
-  books,
-  blog,
-  talks,
-  zenn,
-  note,
-  podcast,
+	about,
+	works,
+	books,
+	blog,
+	talks,
+	zenn,
+	note,
+	podcast,
 };

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -810,12 +810,12 @@ const categories: Category[] = [
 			},
 			{
 				name: "Codex",
-				description: "OpenAI Codexのコマンドラインインターフェース",
+				description: "ターミナルで動作するOpenAIのコーディングエージェント",
 				url: "https://github.com/openai/codex",
 			},
 			{
 				name: "Kiro",
-				description: "AWSのAIコードアシスタント",
+				description: "スペック駆動開発のためのエージェント中心型IDE（AWS製）",
 				url: "https://kiro.dev/",
 			},
 			{

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -108,6 +108,11 @@ const categories: Category[] = [
 				description: "カラフルなコマンドライン16進数ビューア",
 				url: "https://github.com/sharkdp/hexyl",
 			},
+			{
+				name: "SmoothCSV",
+				description: "高速で使いやすいCSVエディタ",
+				url: "https://smoothcsv.com/",
+			},
 		],
 	},
 	{
@@ -338,6 +343,11 @@ const categories: Category[] = [
 				description: "コード統計を表示するプログラム",
 				url: "https://github.com/XAMPPRocky/tokei",
 			},
+			{
+				name: "Expressions",
+				description: "正規表現テスター・デバッガー",
+				url: "https://www.apptorium.com/expressions",
+			},
 		],
 	},
 	{
@@ -560,6 +570,11 @@ const categories: Category[] = [
 				description: "ゲーマー向けブラウザ",
 				url: "https://www.opera.com/gx",
 			},
+			{
+				name: "Opera Air",
+				description: "AI機能を統合したOpera新ブラウザ",
+				url: "https://www.opera.com/air",
+			},
 		],
 	},
 	{
@@ -590,6 +605,11 @@ const categories: Category[] = [
 				name: "Signal",
 				description: "プライバシー重視のメッセージングアプリ",
 				url: "https://signal.org/",
+			},
+			{
+				name: "Legcord",
+				description: "カスタマイズ可能なDiscord代替クライアント",
+				url: "https://legcord.app/",
 			},
 		],
 	},
@@ -637,6 +657,11 @@ const categories: Category[] = [
 				name: "Cycling '74 Max",
 				description: "ビジュアルプログラミング言語（音楽・マルチメディア）",
 				url: "https://cycling74.com/",
+			},
+			{
+				name: "Forecast",
+				description: "ポッドキャストのチャプター・メタデータエディタ",
+				url: "https://overcast.fm/forecast",
 			},
 		],
 	},
@@ -783,6 +808,31 @@ const categories: Category[] = [
 				description: "Claude AIの開発ツール（CLI）",
 				url: "https://docs.anthropic.com/en/docs/claude-code/overview",
 			},
+			{
+				name: "Codex",
+				description: "OpenAI Codexのコマンドラインインターフェース",
+				url: "https://github.com/openai/codex",
+			},
+			{
+				name: "Kiro",
+				description: "AWSのAIコードアシスタント",
+				url: "https://kiro.dev/",
+			},
+			{
+				name: "Limitless",
+				description: "AI会議レコーダー・アシスタント",
+				url: "https://www.limitless.ai/",
+			},
+			{
+				name: "Aqua Voice",
+				description: "AI音声入力ツール",
+				url: "https://withaqua.com/",
+			},
+			{
+				name: "Trae",
+				description: "AIアシスタント",
+				url: "https://www.trae.ai/",
+			},
 		],
 	},
 	{
@@ -823,6 +873,11 @@ const categories: Category[] = [
 				name: "Gyazo",
 				description: "スクリーンショット共有ツール",
 				url: "https://gyazo.com/",
+			},
+			{
+				name: "AZooKey",
+				description: "カスタマイズ可能なmacOS用日本語キーボード",
+				url: "https://github.com/azooKey/azooKey-Desktop",
 			},
 		],
 	},


### PR DESCRIPTION
Add 11 applications from brew list --cask that were not listed:
- AI: Codex, Kiro, Limitless, Aqua Voice, Trae
- Browser: Opera Air
- Communication: Legcord
- Audio: Forecast
- File: SmoothCSV
- Dev: Expressions
- Utility: AZooKey

Also includes Biome formatting fix for content.config.ts

Closes TA-41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new tools to the tools page, including applications for CSV editing, regular expression testing, web browsing, communication, podcast production, AI-powered agents, system customization, and entertainment across multiple categories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->