### PR TITLE
refactor: サイト設定ファイルを作成して定数を集中管理

### DIFF
--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,11 @@
+export const SITE = {
+	name: "Portfolio",
+	description: "個人ポートフォリオサイト",
+	author: "Takumi Abe",
+	url: "https://ta93abe.com",
+	slidesUrl: "https://slides.ta93abe.com",
+	locale: "ja_JP",
+	lang: "ja",
+} as const;
+
+export type SiteConfig = typeof SITE;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import "../styles/global.css";
 import Footer from "../components/Footer.astro";
 import Header from "../components/Header.astro";
+import { SITE } from "../config/site";
 
 interface Props {
 	title?: string;
@@ -16,11 +17,11 @@ interface Props {
 }
 
 const {
-	title = "Portfolio",
-	description = "個人ポートフォリオサイト",
+	title = SITE.name,
+	description = SITE.description,
 	ogImage = "/og-image.png",
 	ogImageAlt = title,
-	ogSiteName = "Portfolio",
+	ogSiteName = SITE.name,
 	ogType = "website",
 	noHeader = false,
 	noFooter = false,
@@ -43,7 +44,7 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		<title>{title}</title>
 		<meta name="title" content={title} />
 		<meta name="description" content={description} />
-		<meta name="author" content="Takumi Abe" />
+		<meta name="author" content={SITE.author} />
 		<link rel="canonical" href={canonicalURL} />
 
 		<!-- Open Graph / Facebook -->
@@ -54,7 +55,7 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		<meta property="og:image" content={ogImageURL} />
 		<meta property="og:image:alt" content={ogImageAlt} />
 		<meta property="og:site_name" content={ogSiteName} />
-		<meta property="og:locale" content="ja_JP" />
+		<meta property="og:locale" content={SITE.locale} />
 
 		<!-- Twitter -->
 		<meta name="twitter:card" content="summary_large_image" />
@@ -65,21 +66,22 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		<meta name="twitter:image:alt" content={ogImageAlt} />
 
 		<!-- 構造化データ (JSON-LD) -->
-		<script type="application/ld+json">
-			{
+		<script
+			type="application/ld+json"
+			set:html={JSON.stringify({
 				"@context": "https://schema.org",
 				"@type": "WebSite",
-				"name": "Portfolio",
-				"url": Astro.site.href,
-				"description": "個人ポートフォリオサイト",
-				"author": {
+				name: SITE.name,
+				url: Astro.site?.href,
+				description: SITE.description,
+				author: {
 					"@type": "Person",
-					"name": "Takumi Abe",
-					"url": Astro.site.href
+					name: SITE.author,
+					url: Astro.site?.href,
 				},
-				"inLanguage": "ja"
-			}
-		</script>
+				inLanguage: SITE.lang,
+			})}
+		></script>
 		<slot name="head" />
 	</head>
 	<body>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,9 +1,10 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import { SITE } from "../config/site";
 ---
 
 <Layout
-  title="404 - ページが見つかりません | Portfolio"
+  title={`404 - ページが見つかりません | ${SITE.name}`}
   description="お探しのページは見つかりませんでした。"
 >
   <main class="flex min-h-screen items-center justify-center px-6">

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from "astro:content";
 import Breadcrumb from "../../components/Breadcrumb.astro";
 import Layout from "../../layouts/Layout.astro";
+import { SITE } from "../../config/site";
 import { formatDate } from "../../utils/date";
 
 export async function getStaticPaths() {
@@ -29,24 +30,24 @@ const blogSchema = {
 	dateModified: modifiedTime,
 	author: {
 		"@type": "Person",
-		name: "Takumi Abe",
+		name: SITE.author,
 		url: Astro.site?.href,
 	},
 	image: ogImageURL.href,
 	mainEntityOfPage: canonicalURL.href,
-	inLanguage: "ja",
+	inLanguage: SITE.lang,
 };
 ---
 
 <Layout
-  title={`${post.data.title} | Blog | Portfolio`}
+  title={`${post.data.title} | Blog | ${SITE.name}`}
   description={post.data.excerpt}
   ogType="article"
   ogImage={ogImageURL.href}
   ogImageAlt={post.data.title}
 >
   <Fragment slot="head">
-    <meta property="article:author" content="Takumi Abe" />
+    <meta property="article:author" content={SITE.author} />
     <meta property="article:published_time" content={publishedTime} />
     {
       post.data.updatedDate && (

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
+import { SITE } from "../../config/site";
 import { formatDate } from "../../utils/date";
 
 const blogPosts = await getCollection("blog");
@@ -10,7 +11,7 @@ const sortedPosts = blogPosts.sort(
 ---
 
 <Layout
-  title="Blog | Portfolio"
+  title={`Blog | ${SITE.name}`}
   description="技術ブログ。日々の学びや開発の記録を共有しています。"
 >
   <link

--- a/src/pages/bookshelf/[id].astro
+++ b/src/pages/bookshelf/[id].astro
@@ -2,6 +2,7 @@
 import { Image } from "astro:assets";
 import { getCollection, render } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
+import { SITE } from "../../config/site";
 import { statusLabels, statusStyles } from "../../utils/books";
 import { formatDate } from "../../utils/date";
 
@@ -34,12 +35,12 @@ const bookSchema = {
 	image: ogImageURL.href,
 	genre: tags.join(", "),
 	url: canonicalURL.href,
-	inLanguage: "ja",
+	inLanguage: SITE.lang,
 };
 ---
 
 <Layout
-  title={`${book.data.title} | Bookshelf | Portfolio`}
+  title={`${book.data.title} | Bookshelf | ${SITE.name}`}
   description={book.data.excerpt}
   ogType="book"
   ogImage={ogImageURL.href}

--- a/src/pages/bookshelf/index.astro
+++ b/src/pages/bookshelf/index.astro
@@ -2,6 +2,7 @@
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
+import { SITE } from "../../config/site";
 import { statusLabels, statusStyles } from "../../utils/books";
 import { formatDate } from "../../utils/date";
 
@@ -15,7 +16,7 @@ const sortedBooks = [...books].sort((a, b) => {
 ---
 
 <Layout
-  title="Bookshelf | Portfolio"
+  title={`Bookshelf | ${SITE.name}`}
   description="読書記録と書評の一覧。読んだ本や積読のメモをまとめています。"
 >
   <main class="mx-auto max-w-6xl px-6 py-12">

--- a/src/pages/links.astro
+++ b/src/pages/links.astro
@@ -1,10 +1,11 @@
 ---
 import SnsLinks from "../components/SnsLinks.astro";
 import Layout from "../layouts/Layout.astro";
+import { SITE } from "../config/site";
 ---
 
 <Layout
-  title="Links | Portfolio"
+  title={`Links | ${SITE.name}`}
   description="SNSやソーシャルメディアのリンク一覧です。"
 >
   <main class="mx-auto max-w-4xl px-6 py-12">

--- a/src/pages/slides.astro
+++ b/src/pages/slides.astro
@@ -1,8 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import { SITE } from "../config/site";
 import { formatDate } from "../utils/date";
-
-const SLIDES_BASE_URL = "https://slides.ta93abe.com";
 
 interface Slide {
 	url: string;
@@ -15,7 +14,7 @@ let slides: Slide[] = [];
 let error: string | null = null;
 
 try {
-	const res = await fetch(`${SLIDES_BASE_URL}/slides.json`, {
+	const res = await fetch(`${SITE.slidesUrl}/slides.json`, {
 		signal: AbortSignal.timeout(10000),
 	});
 	if (res.ok) {
@@ -30,7 +29,7 @@ try {
 ---
 
 <Layout
-  title="Slides | Portfolio"
+  title={`Slides | ${SITE.name}`}
   description="登壇やLTで使用したスライドの一覧です。"
 >
   <main class="mx-auto max-w-4xl px-6 py-12">
@@ -46,7 +45,7 @@ try {
         <div class="space-y-6">
           {slides.map((slide) => (
             <a
-              href={`${SLIDES_BASE_URL}${slide.url}`}
+              href={`${SITE.slidesUrl}${slide.url}`}
               target="_blank"
               rel="noopener noreferrer"
               class="group block rounded-lg border border-gray-200 p-6 transition-all hover:border-gray-300 hover:bg-gray-50 hover:shadow-sm"

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import { SITE } from "../config/site";
 
 type Tool = {
 	name: string;
@@ -913,7 +914,7 @@ const enablePagefind = !import.meta.env.DEV;
 ---
 
 <Layout
-	title="Tools | Portfolio"
+	title={`Tools | ${SITE.name}`}
 	description="開発で使用しているツールやアプリケーションの一覧です。"
 >
 	<main class="mx-auto max-w-6xl px-6 py-12">

--- a/src/pages/works/[id].astro
+++ b/src/pages/works/[id].astro
@@ -3,6 +3,7 @@ import { Image } from "astro:assets";
 import { getCollection, render } from "astro:content";
 import Breadcrumb from "../../components/Breadcrumb.astro";
 import Layout from "../../layouts/Layout.astro";
+import { SITE } from "../../config/site";
 import { formatDate } from "../../utils/date";
 
 export async function getStaticPaths() {
@@ -32,23 +33,23 @@ const workSchema = {
 	dateModified: modifiedTime,
 	author: {
 		"@type": "Person",
-		name: "Takumi Abe",
-		url: Astro.site.href,
+		name: SITE.author,
+		url: Astro.site?.href,
 	},
 	url: canonicalURL.href,
-	inLanguage: "ja",
+	inLanguage: SITE.lang,
 };
 ---
 
 <Layout
-  title={`${work.data.title} | Works | Portfolio`}
+  title={`${work.data.title} | Works | ${SITE.name}`}
   description={work.data.excerpt}
   ogType="article"
   ogImage={ogImageURL.href}
   ogImageAlt={work.data.title}
 >
   <Fragment slot="head">
-    <meta property="article:author" content="Takumi Abe" />
+    <meta property="article:author" content={SITE.author} />
     <meta property="article:published_time" content={createdTime} />
     {
       work.data.endDate && (

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -2,6 +2,7 @@
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
+import { SITE } from "../../config/site";
 
 const works = await getCollection("works");
 const sortedWorks = works.sort(
@@ -10,7 +11,7 @@ const sortedWorks = works.sort(
 ---
 
 <Layout
-  title="Works | Portfolio"
+  title={`Works | ${SITE.name}`}
   description="ポートフォリオ作品一覧。これまでに手がけたプロジェクトをご覧ください。"
 >
   <main class="mx-auto max-w-6xl px-6 py-12">


### PR DESCRIPTION
src/config/site.ts を作成し、サイト名、著者名、言語設定などの
ハードコードされた定数を一元管理。

変更内容:
- SITE.name, SITE.author, SITE.locale, SITE.lang, SITE.slidesUrl を定義
- Layout.astro: デフォルト値とJSON-LDでSITE設定を使用
- 各ページ: タイトルとmeta情報でSITE設定を使用
- blog/[id].astro, works/[id].astro: 構造化データでSITE設定を使用

Linear: TA-43

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>