### PR TITLE
refactor: extract common Tag and Badge UI components

### DIFF
--- a/src/components/ui/Badge.astro
+++ b/src/components/ui/Badge.astro
@@ -1,0 +1,20 @@
+---
+import { statusLabels, statusStyles } from "../../utils/books";
+
+interface Props {
+	variant?: keyof typeof statusLabels;
+	class?: string;
+}
+
+const { variant = "reading", class: className = "" } = Astro.props;
+---
+
+<span
+  class:list={[
+    "rounded-full px-3 py-1 text-xs font-semibold",
+    statusStyles[variant],
+    className,
+  ]}
+>
+  {statusLabels[variant]}
+</span>

--- a/src/components/ui/Tag.astro
+++ b/src/components/ui/Tag.astro
@@ -1,0 +1,25 @@
+---
+const variantStyles = {
+	default: "bg-gray-100 text-gray-700",
+	success: "bg-green-100 text-green-800",
+	warning: "bg-yellow-100 text-yellow-800",
+	info: "bg-blue-100 text-blue-800",
+};
+
+interface Props {
+	variant?: keyof typeof variantStyles;
+	class?: string;
+}
+
+const { variant = "default", class: className = "" } = Astro.props;
+---
+
+<span
+  class:list={[
+    "rounded-full px-3 py-1 text-xs",
+    variantStyles[variant],
+    className,
+  ]}
+>
+  <slot />
+</span>

--- a/src/content/books/sample-book.md
+++ b/src/content/books/sample-book.md
@@ -1,7 +1,7 @@
 ---
 title: "サンプルブック"
 author: "著者名"
-coverImage: "../../assets/astro.svg"
+coverImage: "../../../public/favicon.svg"
 status: "read"
 finishedDate: 2024-06-30
 rating: 4

--- a/src/content/works/sample-project.md
+++ b/src/content/works/sample-project.md
@@ -1,6 +1,6 @@
 ---
 title: "サンプルプロジェクト"
-coverImage: "../../assets/astro.svg"
+coverImage: "../../../public/favicon.svg"
 keywords: ["Astro", "TypeScript", "Tailwind CSS"]
 startDate: 2024-01-01
 endDate: 2024-12-31

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from "astro:content";
 import Breadcrumb from "../../components/Breadcrumb.astro";
+import Tag from "../../components/ui/Tag.astro";
 import Layout from "../../layouts/Layout.astro";
 import { SITE } from "../../config/site";
 import { formatDate } from "../../utils/date";
@@ -90,9 +91,7 @@ const blogSchema = {
           post.data.tags && post.data.tags.length > 0 && (
             <div class="flex flex-wrap gap-2">
               {post.data.tags.map((tag: string) => (
-                <span class="rounded-full bg-gray-100 px-3 py-1 text-xs text-gray-700">
-                  {tag}
-                </span>
+                <Tag>{tag}</Tag>
               ))}
             </div>
           )

--- a/src/pages/bookshelf/[id].astro
+++ b/src/pages/bookshelf/[id].astro
@@ -1,9 +1,10 @@
 ---
 import { Image } from "astro:assets";
 import { getCollection, render } from "astro:content";
+import Badge from "../../components/ui/Badge.astro";
+import Tag from "../../components/ui/Tag.astro";
 import Layout from "../../layouts/Layout.astro";
 import { SITE } from "../../config/site";
-import { statusLabels, statusStyles } from "../../utils/books";
 import { formatDate } from "../../utils/date";
 
 export async function getStaticPaths() {
@@ -65,16 +66,10 @@ const bookSchema = {
       <h1 class="mb-2 text-4xl font-bold">{book.data.title}</h1>
       <p class="mb-4 text-lg text-gray-700">{book.data.author}</p>
       <div class="mb-4 flex flex-wrap items-center gap-2">
-        <span
-          class={`rounded-full px-3 py-1 text-xs font-semibold ${statusStyles[book.data.status]}`}
-        >
-          {statusLabels[book.data.status]}
-        </span>
+        <Badge variant={book.data.status} />
         {
           book.data.category && (
-            <span class="rounded-full bg-gray-100 px-3 py-1 text-xs">
-              {book.data.category}
-            </span>
+            <Tag>{book.data.category}</Tag>
           )
         }
         {
@@ -93,13 +88,7 @@ const bookSchema = {
         }
       </div>
       <div class="flex flex-wrap gap-2">
-        {
-          tags.map((tag) => (
-            <span class="rounded-full bg-gray-100 px-3 py-1 text-xs">
-              {tag}
-            </span>
-          ))
-        }
+        {tags.map((tag) => <Tag>{tag}</Tag>)}
       </div>
     </div>
 

--- a/src/pages/bookshelf/index.astro
+++ b/src/pages/bookshelf/index.astro
@@ -1,9 +1,10 @@
 ---
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
+import Badge from "../../components/ui/Badge.astro";
+import Tag from "../../components/ui/Tag.astro";
 import Layout from "../../layouts/Layout.astro";
 import { SITE } from "../../config/site";
-import { statusLabels, statusStyles } from "../../utils/books";
 import { formatDate } from "../../utils/date";
 
 const books = await getCollection("books");
@@ -38,16 +39,8 @@ const sortedBooks = [...books].sort((a, b) => {
             </div>
             <div class="p-4">
               <div class="mb-3 flex flex-wrap items-center gap-2">
-                <span
-                  class={`rounded-full px-3 py-1 text-xs font-semibold ${statusStyles[book.data.status]}`}
-                >
-                  {statusLabels[book.data.status]}
-                </span>
-                {book.data.category && (
-                  <span class="rounded-full bg-gray-100 px-3 py-1 text-xs">
-                    {book.data.category}
-                  </span>
-                )}
+                <Badge variant={book.data.status} />
+                {book.data.category && <Tag>{book.data.category}</Tag>}
               </div>
               <h2 class="mb-1 text-xl font-bold">{book.data.title}</h2>
               <p class="mb-2 text-sm text-gray-600">{book.data.author}</p>
@@ -58,11 +51,7 @@ const sortedBooks = [...books].sort((a, b) => {
               )}
               <p class="mb-3 text-sm text-gray-700">{book.data.excerpt}</p>
               <div class="flex flex-wrap gap-2">
-                {book.data.tags.map((tag) => (
-                  <span class="rounded bg-gray-100 px-2 py-1 text-xs">
-                    {tag}
-                  </span>
-                ))}
+                {book.data.tags.map((tag) => <Tag>{tag}</Tag>)}
               </div>
               {book.data.rating && (
                 <p class="mt-3 text-xs text-gray-600">


### PR DESCRIPTION
- Add src/components/ui/Tag.astro for reusable tag styling
- Add src/components/ui/Badge.astro for book status badges
- Update blog/[id].astro to use Tag component
- Update bookshelf pages to use Badge and Tag components
- Remove duplicate statusLabels/statusStyles imports from bookshelf pages

Fixes: TA-45