### PR TITLE
feat(seo): add BreadcrumbList and SearchAction structured data

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import "../styles/global.css";
 import Footer from "../components/Footer.astro";
 import Header from "../components/Header.astro";
 import { SITE } from "../config/site";
+import { generateWebSiteSchema, stringifySchema } from "../utils/schema";
 
 interface Props {
 	title?: string;
@@ -68,19 +69,7 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		<!-- 構造化データ (JSON-LD) -->
 		<script
 			type="application/ld+json"
-			set:html={JSON.stringify({
-				"@context": "https://schema.org",
-				"@type": "WebSite",
-				name: SITE.name,
-				url: Astro.site?.href,
-				description: SITE.description,
-				author: {
-					"@type": "Person",
-					name: SITE.author,
-					url: Astro.site?.href,
-				},
-				inLanguage: SITE.lang,
-			})}
+			set:html={stringifySchema(generateWebSiteSchema(Astro.site?.href || SITE.url))}
 		></script>
 		<slot name="head" />
 	</head>

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -2,9 +2,10 @@
 import { getCollection, render } from "astro:content";
 import Breadcrumb from "../../components/Breadcrumb.astro";
 import Tag from "../../components/ui/Tag.astro";
-import Layout from "../../layouts/Layout.astro";
 import { SITE } from "../../config/site";
+import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
+import { generateBreadcrumbSchema, stringifySchema } from "../../utils/schema";
 
 export async function getStaticPaths() {
 	const blogPosts = await getCollection("blog");
@@ -38,6 +39,12 @@ const blogSchema = {
 	mainEntityOfPage: canonicalURL.href,
 	inLanguage: SITE.lang,
 };
+const breadcrumbItems = [
+	{ label: "ホーム", href: "/" },
+	{ label: "ブログ", href: "/blog" },
+	{ label: post.data.title },
+];
+const siteUrl = Astro.site?.href || SITE.url;
 ---
 
 <Layout
@@ -57,17 +64,15 @@ const blogSchema = {
     }
     <script
       type="application/ld+json"
-      set:html={JSON.stringify(blogSchema).replace(/</g, "\\u003c")}
+      set:html={stringifySchema(blogSchema)}
+    />
+    <script
+      type="application/ld+json"
+      set:html={stringifySchema(generateBreadcrumbSchema(breadcrumbItems, siteUrl))}
     />
   </Fragment>
   <main class="mx-auto max-w-4xl px-6 py-12">
-    <Breadcrumb
-      items={[
-        { label: "ホーム", href: "/" },
-        { label: "ブログ", href: "/blog" },
-        { label: post.data.title },
-      ]}
-    />
+    <Breadcrumb items={breadcrumbItems} />
     <div class="mb-8">
       <a
         href="/blog"

--- a/src/pages/bookshelf/[id].astro
+++ b/src/pages/bookshelf/[id].astro
@@ -1,11 +1,13 @@
 ---
 import { Image } from "astro:assets";
 import { getCollection, render } from "astro:content";
+import Breadcrumb from "../../components/Breadcrumb.astro";
 import Badge from "../../components/ui/Badge.astro";
 import Tag from "../../components/ui/Tag.astro";
-import Layout from "../../layouts/Layout.astro";
 import { SITE } from "../../config/site";
+import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
+import { generateBreadcrumbSchema, stringifySchema } from "../../utils/schema";
 
 export async function getStaticPaths() {
 	const books = await getCollection("books");
@@ -38,6 +40,12 @@ const bookSchema = {
 	url: canonicalURL.href,
 	inLanguage: SITE.lang,
 };
+const breadcrumbItems = [
+	{ label: "ホーム", href: "/" },
+	{ label: "Bookshelf", href: "/bookshelf" },
+	{ label: book.data.title },
+];
+const siteUrl = Astro.site?.href || SITE.url;
 ---
 
 <Layout
@@ -52,10 +60,15 @@ const bookSchema = {
     {tags.map((tag) => <meta property="book:tag" content={tag} />)}
     <script
       type="application/ld+json"
-      set:html={JSON.stringify(bookSchema).replace(/</g, "\\u003c")}
+      set:html={stringifySchema(bookSchema)}
+    />
+    <script
+      type="application/ld+json"
+      set:html={stringifySchema(generateBreadcrumbSchema(breadcrumbItems, siteUrl))}
     />
   </Fragment>
   <main class="mx-auto max-w-4xl px-6 py-12">
+    <Breadcrumb items={breadcrumbItems} />
     <div class="mb-8">
       <a
         href="/bookshelf"

--- a/src/pages/works/[id].astro
+++ b/src/pages/works/[id].astro
@@ -2,9 +2,10 @@
 import { Image } from "astro:assets";
 import { getCollection, render } from "astro:content";
 import Breadcrumb from "../../components/Breadcrumb.astro";
-import Layout from "../../layouts/Layout.astro";
 import { SITE } from "../../config/site";
+import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
+import { generateBreadcrumbSchema, stringifySchema } from "../../utils/schema";
 
 export async function getStaticPaths() {
 	const works = await getCollection("works");
@@ -39,6 +40,12 @@ const workSchema = {
 	url: canonicalURL.href,
 	inLanguage: SITE.lang,
 };
+const breadcrumbItems = [
+	{ label: "ホーム", href: "/" },
+	{ label: "Works", href: "/works" },
+	{ label: work.data.title },
+];
+const siteUrl = Astro.site?.href || SITE.url;
 ---
 
 <Layout
@@ -58,17 +65,15 @@ const workSchema = {
     }
     <script
       type="application/ld+json"
-      set:html={JSON.stringify(workSchema).replace(/</g, "\\u003c")}
+      set:html={stringifySchema(workSchema)}
+    />
+    <script
+      type="application/ld+json"
+      set:html={stringifySchema(generateBreadcrumbSchema(breadcrumbItems, siteUrl))}
     />
   </Fragment>
   <main class="mx-auto max-w-4xl px-6 py-12">
-    <Breadcrumb
-      items={[
-        { label: "ホーム", href: "/" },
-        { label: "Works", href: "/works" },
-        { label: work.data.title },
-      ]}
-    />
+    <Breadcrumb items={breadcrumbItems} />
     <div class="mb-8">
       <a
         href="/works"

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,0 +1,119 @@
+import { SITE } from "../config/site";
+
+export interface BreadcrumbItem {
+	label: string;
+	href?: string;
+}
+
+interface BreadcrumbListItem {
+	"@type": "ListItem";
+	position: number;
+	name: string;
+	item?: string;
+}
+
+interface BreadcrumbListSchema {
+	"@context": "https://schema.org";
+	"@type": "BreadcrumbList";
+	itemListElement: BreadcrumbListItem[];
+}
+
+/**
+ * Generate BreadcrumbList JSON-LD schema
+ * @param items - Array of breadcrumb items with label and optional href
+ * @param siteUrl - Base URL for absolute URLs
+ */
+export const generateBreadcrumbSchema = (
+	items: BreadcrumbItem[],
+	siteUrl: string,
+): BreadcrumbListSchema => {
+	return {
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		itemListElement: items.map((item, index) => {
+			const listItem: BreadcrumbListItem = {
+				"@type": "ListItem",
+				position: index + 1,
+				name: item.label,
+			};
+			// Only add item URL if href is provided (not the current page)
+			if (item.href) {
+				listItem.item = new URL(item.href, siteUrl).href;
+			}
+			return listItem;
+		}),
+	};
+};
+
+interface WebSiteSchema {
+	"@context": "https://schema.org";
+	"@type": "WebSite";
+	name: string;
+	url: string;
+	description: string;
+	author: {
+		"@type": "Person";
+		name: string;
+		url: string;
+	};
+	inLanguage: string;
+	potentialAction?: {
+		"@type": "SearchAction";
+		target: {
+			"@type": "EntryPoint";
+			urlTemplate: string;
+		};
+		"query-input": string;
+	};
+}
+
+interface WebSiteSchemaOptions {
+	includeSearchAction?: boolean;
+}
+
+/**
+ * Generate WebSite JSON-LD schema
+ * @param siteUrl - Base URL for the site
+ * @param options - Optional configuration
+ */
+export const generateWebSiteSchema = (
+	siteUrl: string,
+	options: WebSiteSchemaOptions = {},
+): WebSiteSchema => {
+	const { includeSearchAction = true } = options;
+
+	const schema: WebSiteSchema = {
+		"@context": "https://schema.org",
+		"@type": "WebSite",
+		name: SITE.name,
+		url: siteUrl,
+		description: SITE.description,
+		author: {
+			"@type": "Person",
+			name: SITE.author,
+			url: siteUrl,
+		},
+		inLanguage: SITE.lang,
+	};
+
+	if (includeSearchAction) {
+		schema.potentialAction = {
+			"@type": "SearchAction",
+			target: {
+				"@type": "EntryPoint",
+				urlTemplate: `${siteUrl}tools?q={search_term_string}`,
+			},
+			"query-input": "required name=search_term_string",
+		};
+	}
+
+	return schema;
+};
+
+/**
+ * Safely stringify JSON-LD for embedding in HTML
+ * Escapes < characters to prevent script injection
+ */
+export const stringifySchema = (schema: object): string => {
+	return JSON.stringify(schema).replace(/</g, "\\u003c");
+};


### PR DESCRIPTION
Add schema.ts utility for generating JSON-LD structured data:
- generateBreadcrumbSchema for BreadcrumbList
- generateWebSiteSchema with SearchAction
- stringifySchema helper for safe JSON embedding

Update Layout.astro with SearchAction in WebSite schema
Add BreadcrumbList JSON-LD to blog, works, and bookshelf detail pages
Add Breadcrumb component to bookshelf detail page

Closes TA-54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added breadcrumb navigation to blog, bookshelf, and works detail pages for enhanced user navigation.

* **Refactor**
  * Centralized structured data generation with new schema utilities for consistent JSON-LD handling across multiple pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->