### PR TITLE
feat: add dark mode support

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 // ヘッダーコンポーネント
 import Logo from "./Logo.astro";
+import ThemeToggle from "./ui/ThemeToggle.astro";
 
 const navLinks = [
 	{ href: "/works", text: "Works" },
@@ -13,7 +14,7 @@ const currentPath = Astro.url.pathname;
 ---
 
 <header
-  class="sticky top-0 z-50 border-b border-gray-200 bg-white/80 backdrop-blur-sm"
+  class="sticky top-0 z-50 border-b border-gray-200 bg-white/80 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/80"
 >
   <nav
     class="mx-auto flex max-w-7xl items-center justify-between px-6 py-4"
@@ -22,31 +23,36 @@ const currentPath = Astro.url.pathname;
     <Logo />
 
     <!-- デスクトップナビゲーション -->
-    <ul class="hidden gap-6 md:flex">
-      {
-        navLinks.map((link) => (
-          <li>
-            <a
-              href={link.href}
-              class="hover:opacity-70"
-              aria-current={(link.href === "/" ? currentPath === "/" : currentPath.startsWith(link.href)) ? "page" : undefined}
-            >
-              {link.text}
-            </a>
-          </li>
-        ))
-      }
-    </ul>
+    <div class="hidden items-center gap-6 md:flex">
+      <ul class="flex gap-6">
+        {
+          navLinks.map((link) => (
+            <li>
+              <a
+                href={link.href}
+                class="hover:opacity-70 dark:text-gray-200"
+                aria-current={(link.href === "/" ? currentPath === "/" : currentPath.startsWith(link.href)) ? "page" : undefined}
+              >
+                {link.text}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+      <ThemeToggle />
+    </div>
 
-    <!-- モバイルハンバーガーボタン -->
-    <button
-      type="button"
-      id="mobile-menu-button"
-      class="flex h-10 w-10 items-center justify-center rounded-lg hover:bg-gray-100 md:hidden"
-      aria-label="メニューを開く"
-      aria-expanded="false"
-      aria-controls="mobile-menu"
-    >
+    <!-- モバイル: テーマ切り替え + ハンバーガー -->
+    <div class="flex items-center gap-2 md:hidden">
+      <ThemeToggle />
+      <button
+        type="button"
+        id="mobile-menu-button"
+        class="flex h-10 w-10 items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
+        aria-label="メニューを開く"
+        aria-expanded="false"
+        aria-controls="mobile-menu"
+      >
       <svg
         id="menu-icon-open"
         class="h-6 w-6"
@@ -75,13 +81,14 @@ const currentPath = Astro.url.pathname;
           stroke-width="2"
           d="M6 18L18 6M6 6l12 12"></path>
       </svg>
-    </button>
+      </button>
+    </div>
   </nav>
 
   <!-- モバイルメニュー -->
   <div
     id="mobile-menu"
-    class="hidden border-t border-gray-200 bg-white md:hidden"
+    class="hidden border-t border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900 md:hidden"
     aria-hidden="true"
   >
     <ul class="space-y-1 px-6 py-4">
@@ -90,7 +97,7 @@ const currentPath = Astro.url.pathname;
           <li>
             <a
               href={link.href}
-              class="block rounded-lg px-4 py-3 text-lg hover:bg-gray-100"
+              class="block rounded-lg px-4 py-3 text-lg hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
               aria-current={(link.href === "/" ? currentPath === "/" : currentPath.startsWith(link.href)) ? "page" : undefined}
             >
               {link.text}

--- a/src/components/ui/ThemeToggle.astro
+++ b/src/components/ui/ThemeToggle.astro
@@ -1,0 +1,96 @@
+---
+interface Props {
+	class?: string;
+}
+
+const { class: className = "" } = Astro.props;
+---
+
+<button
+	id="theme-toggle"
+	class:list={[
+		"flex size-10 items-center justify-center rounded-full text-gray-600 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800",
+		className,
+	]}
+	aria-label="テーマを切り替え"
+>
+	<!-- Sun icon (light mode) -->
+	<svg
+		id="theme-light-icon"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 20 20"
+		fill="currentColor"
+		class="hidden size-5"
+	>
+		<path
+			d="M10 2a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 10 2ZM10 15a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 10 15ZM10 7a3 3 0 1 0 0 6 3 3 0 0 0 0-6ZM15.657 5.404a.75.75 0 1 0-1.06-1.06l-1.061 1.06a.75.75 0 0 0 1.06 1.061l1.061-1.06ZM6.464 14.596a.75.75 0 1 0-1.06-1.06l-1.06 1.06a.75.75 0 0 0 1.06 1.06l1.06-1.06ZM18 10a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 18 10ZM5 10a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 5 10ZM14.596 15.657a.75.75 0 0 0 1.06-1.06l-1.06-1.061a.75.75 0 1 0-1.061 1.06l1.06 1.061ZM5.404 6.464a.75.75 0 0 0 1.06-1.06l-1.06-1.06a.75.75 0 1 0-1.061 1.06l1.06 1.06Z"
+		/>
+	</svg>
+	<!-- Moon icon (dark mode) -->
+	<svg
+		id="theme-dark-icon"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 20 20"
+		fill="currentColor"
+		class="hidden size-5"
+	>
+		<path
+			fill-rule="evenodd"
+			d="M7.455 2.004a.75.75 0 0 1 .26.77 7 7 0 0 0 9.958 7.967.75.75 0 0 1 1.067.853A8.5 8.5 0 1 1 6.647 1.921a.75.75 0 0 1 .808.083Z"
+			clip-rule="evenodd"
+		/>
+	</svg>
+</button>
+
+<script is:inline>
+	// Initialize theme from localStorage or system preference
+	(function initTheme() {
+		const theme = localStorage.getItem("theme");
+		const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+		if (theme === "dark" || (!theme && prefersDark)) {
+			document.documentElement.classList.add("dark");
+		} else {
+			document.documentElement.classList.remove("dark");
+		}
+
+		updateIcons();
+	})();
+
+	function updateIcons() {
+		const isDark = document.documentElement.classList.contains("dark");
+		const lightIcon = document.getElementById("theme-light-icon");
+		const darkIcon = document.getElementById("theme-dark-icon");
+
+		if (lightIcon && darkIcon) {
+			// Show sun icon in dark mode (click to switch to light)
+			// Show moon icon in light mode (click to switch to dark)
+			if (isDark) {
+				lightIcon.classList.remove("hidden");
+				darkIcon.classList.add("hidden");
+			} else {
+				lightIcon.classList.add("hidden");
+				darkIcon.classList.remove("hidden");
+			}
+		}
+	}
+
+	// Toggle theme on button click
+	document.getElementById("theme-toggle")?.addEventListener("click", () => {
+		const isDark = document.documentElement.classList.toggle("dark");
+		localStorage.setItem("theme", isDark ? "dark" : "light");
+		updateIcons();
+	});
+
+	// Listen for system preference changes
+	window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+		if (!localStorage.getItem("theme")) {
+			if (e.matches) {
+				document.documentElement.classList.add("dark");
+			} else {
+				document.documentElement.classList.remove("dark");
+			}
+			updateIcons();
+		}
+	});
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -40,6 +40,18 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
+		<meta name="color-scheme" content="light dark" />
+
+		<!-- Prevent flash of wrong theme -->
+		<script is:inline>
+			(function() {
+				const theme = localStorage.getItem("theme");
+				const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+				if (theme === "dark" || (!theme && prefersDark)) {
+					document.documentElement.classList.add("dark");
+				}
+			})();
+		</script>
 
 		<!-- Primary Meta Tags -->
 		<title>{title}</title>
@@ -73,7 +85,7 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		></script>
 		<slot name="head" />
 	</head>
-	<body>
+	<body class="bg-white text-gray-900 transition-colors dark:bg-gray-900 dark:text-gray-100">
 		<!-- スキップリンク -->
 		<a href="#main-content" class="skip-link">
 			コンテンツにスキップ

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,9 +3,40 @@
 @import "@fontsource/shippori-mincho/500.css";
 @import "@fontsource/shippori-mincho/700.css";
 
-/* プライマリカラー */
+/* テーマカラー - ライトモード */
 :root {
 	--primary-color: #4f46e5;
+	--bg-primary: #ffffff;
+	--bg-secondary: #f8fafc;
+	--bg-tertiary: #f1f5f9;
+	--text-primary: #1a1a1a;
+	--text-secondary: #4b5563;
+	--text-muted: #9ca3af;
+	--border-color: #e2e8f0;
+	--link-color: #2563eb;
+	--link-hover-color: #1d4ed8;
+	--blockquote-bg: #eff6ff;
+	--blockquote-border: #3b82f6;
+	--code-bg: #f1f5f9;
+	--code-text: #1e293b;
+}
+
+/* テーマカラー - ダークモード */
+:root.dark {
+	--primary-color: #818cf8;
+	--bg-primary: #0f172a;
+	--bg-secondary: #1e293b;
+	--bg-tertiary: #334155;
+	--text-primary: #f1f5f9;
+	--text-secondary: #cbd5e1;
+	--text-muted: #64748b;
+	--border-color: #334155;
+	--link-color: #60a5fa;
+	--link-hover-color: #93c5fd;
+	--blockquote-bg: #1e3a5f;
+	--blockquote-border: #3b82f6;
+	--code-bg: #1e293b;
+	--code-text: #e2e8f0;
 }
 
 /* フォーカス表示の強化 */
@@ -67,12 +98,12 @@
 
 /* Inline code */
 .prose :not(pre) > code {
-	background: #f1f5f9;
+	background: var(--code-bg);
 	padding: 0.125rem 0.375rem;
 	border-radius: 0.25rem;
 	font-size: 0.875em;
 	font-weight: 500;
-	color: #1e293b;
+	color: var(--code-text);
 }
 
 /* Better heading anchors */
@@ -84,8 +115,8 @@
 
 /* Blockquote styling */
 .prose blockquote {
-	border-left-color: #3b82f6;
-	background: #eff6ff;
+	border-left-color: var(--blockquote-border);
+	background: var(--blockquote-bg);
 	padding: 1rem;
 	border-radius: 0 0.5rem 0.5rem 0;
 	font-style: normal;
@@ -102,18 +133,18 @@
 }
 
 .prose th {
-	background: #f8fafc;
+	background: var(--bg-secondary);
 	font-weight: 600;
 }
 
 .prose th,
 .prose td {
-	border: 1px solid #e2e8f0;
+	border: 1px solid var(--border-color);
 	padding: 0.75rem;
 }
 
 .prose tr:hover {
-	background: #f8fafc;
+	background: var(--bg-secondary);
 }
 
 /* Task list styling */
@@ -141,11 +172,11 @@
 
 /* Link styling */
 .prose a {
-	color: #2563eb;
+	color: var(--link-color);
 	text-decoration: underline;
 	text-underline-offset: 2px;
 }
 
 .prose a:hover {
-	color: #1d4ed8;
+	color: var(--link-hover-color);
 }


### PR DESCRIPTION
Implement dark mode with system preference detection:
- Add CSS variables for light/dark themes in global.css
- Create ThemeToggle component for header
- Add theme initialization script to prevent flash
- Update Layout.astro with dark mode body classes
- Update Header.astro with dark mode styling

Features:
- System preference detection (prefers-color-scheme)
- localStorage persistence of user choice
- Smooth transition between themes
- Theme toggle button in header (desktop and mobile)

Closes TA-56