### PR TITLE
perf: lazy load Three.js for better Core Web Vitals

### DIFF
--- a/src/components/landing/ThreeBackground.astro
+++ b/src/components/landing/ThreeBackground.astro
@@ -15,11 +15,16 @@ const { class: className = "" } = Astro.props;
 </div>
 
 <script>
-  import { ParticleScene } from "../../scripts/three/scene";
+  import type { ParticleScene } from "../../scripts/three/scene";
 
   let scene: ParticleScene | null = null;
+  let isInitialized = false;
 
-  function initThree() {
+  async function initThree() {
+    // Prevent double initialization
+    if (isInitialized) return;
+    isInitialized = true;
+
     const container = document.getElementById("three-canvas-container");
     if (!container) {
       console.error(
@@ -29,6 +34,9 @@ const { class: className = "" } = Astro.props;
     }
 
     try {
+      // Dynamic import for better code splitting and lazy loading
+      const { ParticleScene } = await import("../../scripts/three/scene");
+
       scene = new ParticleScene({
         container,
         particleCount: 3000,
@@ -40,17 +48,30 @@ const { class: className = "" } = Astro.props;
     }
   }
 
-  // Initialize on DOMContentLoaded
+  // Lazy load Three.js after the page is interactive
+  // This improves LCP and FID by not blocking the main thread during initial render
+  function scheduleThreeInit() {
+    // Use requestIdleCallback if available, otherwise fallback to setTimeout
+    if ("requestIdleCallback" in window) {
+      requestIdleCallback(() => initThree(), { timeout: 2000 });
+    } else {
+      // Fallback for Safari and older browsers
+      setTimeout(initThree, 100);
+    }
+  }
+
+  // Wait for DOM to be ready, then schedule lazy initialization
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", initThree);
+    document.addEventListener("DOMContentLoaded", scheduleThreeInit);
   } else {
-    initThree();
+    scheduleThreeInit();
   }
 
   // Cleanup Three.js resources before page swap to prevent memory leaks
   document.addEventListener("astro:before-swap", () => {
     scene?.destroy();
     scene = null;
+    isInitialized = false;
   });
 </script>
 

--- a/src/components/ui/Badge.astro
+++ b/src/components/ui/Badge.astro
@@ -1,5 +1,5 @@
 ---
-import { statusLabels, statusStyles } from "../../utils/books";
+import { type statusLabels, statusStyles } from "../../utils/books";
 
 interface Props {
 	variant?: keyof typeof statusLabels;

--- a/src/components/ui/Badge.astro
+++ b/src/components/ui/Badge.astro
@@ -1,5 +1,5 @@
 ---
-import { type statusLabels, statusStyles } from "../../utils/books";
+import { statusLabels, statusStyles } from "../../utils/books";
 
 interface Props {
 	variant?: keyof typeof statusLabels;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -39,6 +39,7 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
+		<meta name="color-scheme" content="light dark" />
 
 		<!-- Primary Meta Tags -->
 		<title>{title}</title>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from "../layouts/Layout.astro";
 import { SITE } from "../config/site";
+import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -2,8 +2,8 @@
 import { getCollection, render } from "astro:content";
 import Breadcrumb from "../../components/Breadcrumb.astro";
 import Tag from "../../components/ui/Tag.astro";
-import Layout from "../../layouts/Layout.astro";
 import { SITE } from "../../config/site";
+import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
 
 export async function getStaticPaths() {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection } from "astro:content";
-import Layout from "../../layouts/Layout.astro";
 import { SITE } from "../../config/site";
+import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
 
 const blogPosts = await getCollection("blog");

--- a/src/pages/bookshelf/[id].astro
+++ b/src/pages/bookshelf/[id].astro
@@ -3,8 +3,8 @@ import { Image } from "astro:assets";
 import { getCollection, render } from "astro:content";
 import Badge from "../../components/ui/Badge.astro";
 import Tag from "../../components/ui/Tag.astro";
-import Layout from "../../layouts/Layout.astro";
 import { SITE } from "../../config/site";
+import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
 
 export async function getStaticPaths() {

--- a/src/pages/bookshelf/index.astro
+++ b/src/pages/bookshelf/index.astro
@@ -3,8 +3,8 @@ import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
 import Badge from "../../components/ui/Badge.astro";
 import Tag from "../../components/ui/Tag.astro";
-import Layout from "../../layouts/Layout.astro";
 import { SITE } from "../../config/site";
+import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
 
 const books = await getCollection("books");

--- a/src/pages/links.astro
+++ b/src/pages/links.astro
@@ -1,7 +1,7 @@
 ---
 import SnsLinks from "../components/SnsLinks.astro";
-import Layout from "../layouts/Layout.astro";
 import { SITE } from "../config/site";
+import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout

--- a/src/pages/slides.astro
+++ b/src/pages/slides.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from "../layouts/Layout.astro";
 import { SITE } from "../config/site";
+import Layout from "../layouts/Layout.astro";
 import { formatDate } from "../utils/date";
 
 interface Slide {

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from "../layouts/Layout.astro";
 import { SITE } from "../config/site";
+import Layout from "../layouts/Layout.astro";
 
 type Tool = {
 	name: string;

--- a/src/pages/works/[id].astro
+++ b/src/pages/works/[id].astro
@@ -2,8 +2,8 @@
 import { Image } from "astro:assets";
 import { getCollection, render } from "astro:content";
 import Breadcrumb from "../../components/Breadcrumb.astro";
-import Layout from "../../layouts/Layout.astro";
 import { SITE } from "../../config/site";
+import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
 
 export async function getStaticPaths() {

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -1,8 +1,8 @@
 ---
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
-import Layout from "../../layouts/Layout.astro";
 import { SITE } from "../../config/site";
+import Layout from "../../layouts/Layout.astro";
 
 const works = await getCollection("works");
 const sortedWorks = works.sort(


### PR DESCRIPTION
- Use dynamic import with requestIdleCallback to defer Three.js loading
- Split Three.js into separate chunk for async loading
- Add meta color-scheme for better dark mode performance
- Improves LCP and FID by not blocking main thread during initial render

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bookshelf now displays books sorted by latest finished date first.

* **Performance**
  * Three.js library now loads lazily during idle time for improved performance.

* **Accessibility**
  * Added support for system color-scheme preferences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->