### PR TITLE
feat(blog): add reading time, share buttons, and back to top

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 // ヘッダーコンポーネント
 import Logo from "./Logo.astro";
+import ThemeToggle from "./ui/ThemeToggle.astro";
 
 const navLinks = [
 	{ href: "/works", text: "Works" },
@@ -13,7 +14,7 @@ const currentPath = Astro.url.pathname;
 ---
 
 <header
-  class="sticky top-0 z-50 border-b border-gray-200 bg-white/80 backdrop-blur-sm"
+  class="sticky top-0 z-50 border-b border-gray-200 bg-white/80 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/80"
 >
   <nav
     class="mx-auto flex max-w-7xl items-center justify-between px-6 py-4"
@@ -22,31 +23,36 @@ const currentPath = Astro.url.pathname;
     <Logo />
 
     <!-- デスクトップナビゲーション -->
-    <ul class="hidden gap-6 md:flex">
-      {
-        navLinks.map((link) => (
-          <li>
-            <a
-              href={link.href}
-              class="hover:opacity-70"
-              aria-current={(link.href === "/" ? currentPath === "/" : currentPath.startsWith(link.href)) ? "page" : undefined}
-            >
-              {link.text}
-            </a>
-          </li>
-        ))
-      }
-    </ul>
+    <div class="hidden items-center gap-6 md:flex">
+      <ul class="flex gap-6">
+        {
+          navLinks.map((link) => (
+            <li>
+              <a
+                href={link.href}
+                class="hover:opacity-70 dark:text-gray-200"
+                aria-current={(link.href === "/" ? currentPath === "/" : currentPath.startsWith(link.href)) ? "page" : undefined}
+              >
+                {link.text}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+      <ThemeToggle />
+    </div>
 
-    <!-- モバイルハンバーガーボタン -->
-    <button
-      type="button"
-      id="mobile-menu-button"
-      class="flex h-10 w-10 items-center justify-center rounded-lg hover:bg-gray-100 md:hidden"
-      aria-label="メニューを開く"
-      aria-expanded="false"
-      aria-controls="mobile-menu"
-    >
+    <!-- モバイル: テーマ切り替え + ハンバーガー -->
+    <div class="flex items-center gap-2 md:hidden">
+      <ThemeToggle />
+      <button
+        type="button"
+        id="mobile-menu-button"
+        class="flex h-10 w-10 items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
+        aria-label="メニューを開く"
+        aria-expanded="false"
+        aria-controls="mobile-menu"
+      >
       <svg
         id="menu-icon-open"
         class="h-6 w-6"
@@ -75,13 +81,14 @@ const currentPath = Astro.url.pathname;
           stroke-width="2"
           d="M6 18L18 6M6 6l12 12"></path>
       </svg>
-    </button>
+      </button>
+    </div>
   </nav>
 
   <!-- モバイルメニュー -->
   <div
     id="mobile-menu"
-    class="hidden border-t border-gray-200 bg-white md:hidden"
+    class="hidden border-t border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900 md:hidden"
     aria-hidden="true"
   >
     <ul class="space-y-1 px-6 py-4">
@@ -90,7 +97,7 @@ const currentPath = Astro.url.pathname;
           <li>
             <a
               href={link.href}
-              class="block rounded-lg px-4 py-3 text-lg hover:bg-gray-100"
+              class="block rounded-lg px-4 py-3 text-lg hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
               aria-current={(link.href === "/" ? currentPath === "/" : currentPath.startsWith(link.href)) ? "page" : undefined}
             >
               {link.text}

--- a/src/components/blog/ShareButtons.astro
+++ b/src/components/blog/ShareButtons.astro
@@ -1,0 +1,79 @@
+---
+interface Props {
+	url: string;
+	title: string;
+	class?: string;
+}
+
+const { url, title, class: className = "" } = Astro.props;
+
+const encodedUrl = encodeURIComponent(url);
+const encodedTitle = encodeURIComponent(title);
+
+const shareLinks = [
+	{
+		name: "X",
+		href: `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`,
+		icon: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>`,
+		label: "Xでシェア",
+	},
+	{
+		name: "Bluesky",
+		href: `https://bsky.app/intent/compose?text=${encodedTitle}%20${encodedUrl}`,
+		icon: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 530" fill="currentColor" class="size-5"><path d="m135.72 44.03c66.496 49.921 138.02 151.14 164.28 205.46 26.262-54.316 97.782-155.54 164.28-205.46 47.98-36.021 125.72-63.892 125.72 24.795 0 17.712-10.155 148.79-16.111 170.07-20.703 73.984-96.144 92.854-163.25 81.433 117.3 19.964 147.14 86.092 82.697 152.22-122.39 125.59-175.91-31.511-189.63-71.766-2.514-7.3797-3.6904-10.832-3.7077-7.8964-0.0174-2.9357-1.1937 0.51669-3.7077 7.8964-13.714 40.255-67.233 197.36-189.63 71.766-64.444-66.128-34.605-132.26 82.697-152.22-67.108 11.421-142.55-7.4491-163.25-81.433-5.9562-21.282-16.111-152.36-16.111-170.07 0-88.687 77.742-60.816 125.72-24.795z"/></svg>`,
+		label: "Blueskyでシェア",
+	},
+	{
+		name: "LINE",
+		href: `https://social-plugins.line.me/lineit/share?url=${encodedUrl}`,
+		icon: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5"><path d="M12 2C6.48 2 2 6.07 2 11.01c0 4.43 3.74 8.12 8.54 8.87.33.06.78.19.9.43.1.22.07.56.03.78l-.14.91c-.04.27-.2 1.05.92.57s6.1-3.59 8.32-6.15C21.8 14.24 22 12.68 22 11.01 22 6.07 17.52 2 12 2zm-3.21 11.64c0 .2-.16.37-.37.37H5.96a.37.37 0 0 1-.37-.37V8.36c0-.2.16-.37.37-.37h.6c.2 0 .37.17.37.37v4.34h1.28c.2 0 .37.16.37.36v.58zm1.74.37a.37.37 0 0 1-.37-.37V8.36c0-.2.16-.37.37-.37h.6c.2 0 .37.17.37.37v5.28c0 .21-.16.37-.37.37h-.6zm4.82 0a.37.37 0 0 1-.3-.15l-1.93-2.64v2.42c0 .21-.16.37-.37.37h-.6a.37.37 0 0 1-.37-.37V8.36c0-.2.16-.37.37-.37h.6c.11 0 .22.05.3.15l1.93 2.64V8.36c0-.2.16-.37.37-.37h.6c.2 0 .37.17.37.37v5.28c0 .21-.17.37-.37.37h-.6zm2.67-2.26a.37.37 0 0 1 .37-.37h1.28c.2 0 .37.16.37.37v.57c0 .2-.16.37-.37.37h-1.28v.88h1.28c.2 0 .37.16.37.36v.58c0 .2-.16.37-.37.37h-2.25a.37.37 0 0 1-.37-.37V8.36c0-.2.17-.37.37-.37h2.25c.2 0 .37.17.37.37v.57c0 .2-.16.37-.37.37h-1.28v.88h1.28c.2 0 .37.17.37.37v.57c0 .2-.16.37-.37.37h-1.28v.26z"/></svg>`,
+		label: "LINEでシェア",
+	},
+];
+---
+
+<div class:list={["flex flex-wrap items-center gap-3", className]}>
+	<span class="text-sm text-gray-600">シェア:</span>
+	{shareLinks.map((link) => (
+		<a
+			href={link.href}
+			target="_blank"
+			rel="noopener noreferrer"
+			class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-200"
+			title={link.label}
+		>
+			<span set:html={link.icon} />
+			<span class="hidden sm:inline">{link.name}</span>
+		</a>
+	))}
+	<button
+		id="copy-url-btn"
+		class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1.5 text-sm text-gray-700 transition-colors hover:bg-gray-200"
+		title="URLをコピー"
+		data-url={url}
+	>
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
+			<path d="M12.232 4.232a2.5 2.5 0 0 1 3.536 3.536l-1.225 1.224a.75.75 0 0 0 1.061 1.06l1.224-1.224a4 4 0 0 0-5.656-5.656l-3 3a4 4 0 0 0 .225 5.865.75.75 0 0 0 .977-1.138 2.5 2.5 0 0 1-.142-3.667l3-3Z" />
+			<path d="M11.603 7.963a.75.75 0 0 0-.977 1.138 2.5 2.5 0 0 1 .142 3.667l-3 3a2.5 2.5 0 0 1-3.536-3.536l1.225-1.224a.75.75 0 0 0-1.061-1.06l-1.224 1.224a4 4 0 1 0 5.656 5.656l3-3a4 4 0 0 0-.225-5.865Z" />
+		</svg>
+		<span id="copy-text" class="hidden sm:inline">コピー</span>
+	</button>
+</div>
+
+<script>
+	const copyBtn = document.getElementById("copy-url-btn");
+	const copyText = document.getElementById("copy-text");
+
+	if (copyBtn && copyText) {
+		copyBtn.addEventListener("click", async () => {
+			const url = copyBtn.dataset.url;
+			if (url) {
+				await navigator.clipboard.writeText(url);
+				copyText.textContent = "コピー済み";
+				setTimeout(() => {
+					copyText.textContent = "コピー";
+				}, 2000);
+			}
+		});
+	}
+</script>

--- a/src/components/ui/BackToTop.astro
+++ b/src/components/ui/BackToTop.astro
@@ -1,0 +1,55 @@
+---
+interface Props {
+	class?: string;
+}
+
+const { class: className = "" } = Astro.props;
+---
+
+<button
+	id="back-to-top"
+	class:list={[
+		"fixed bottom-6 right-6 z-50 flex size-12 items-center justify-center rounded-full bg-gray-800 text-white shadow-lg transition-all duration-300 hover:bg-gray-700",
+		"opacity-0 pointer-events-none",
+		className,
+	]}
+	aria-label="ページトップへ戻る"
+>
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 20 20"
+		fill="currentColor"
+		class="size-5"
+	>
+		<path
+			fill-rule="evenodd"
+			d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z"
+			clip-rule="evenodd"
+		/>
+	</svg>
+</button>
+
+<script>
+	const backToTopBtn = document.getElementById("back-to-top");
+
+	if (backToTopBtn) {
+		const showThreshold = 300;
+
+		const toggleVisibility = () => {
+			if (window.scrollY > showThreshold) {
+				backToTopBtn.classList.remove("opacity-0", "pointer-events-none");
+				backToTopBtn.classList.add("opacity-100", "pointer-events-auto");
+			} else {
+				backToTopBtn.classList.add("opacity-0", "pointer-events-none");
+				backToTopBtn.classList.remove("opacity-100", "pointer-events-auto");
+			}
+		};
+
+		window.addEventListener("scroll", toggleVisibility, { passive: true });
+		toggleVisibility();
+
+		backToTopBtn.addEventListener("click", () => {
+			window.scrollTo({ top: 0, behavior: "smooth" });
+		});
+	}
+</script>

--- a/src/components/ui/ThemeToggle.astro
+++ b/src/components/ui/ThemeToggle.astro
@@ -1,0 +1,96 @@
+---
+interface Props {
+	class?: string;
+}
+
+const { class: className = "" } = Astro.props;
+---
+
+<button
+	id="theme-toggle"
+	class:list={[
+		"flex size-10 items-center justify-center rounded-full text-gray-600 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800",
+		className,
+	]}
+	aria-label="テーマを切り替え"
+>
+	<!-- Sun icon (light mode) -->
+	<svg
+		id="theme-light-icon"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 20 20"
+		fill="currentColor"
+		class="hidden size-5"
+	>
+		<path
+			d="M10 2a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 10 2ZM10 15a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 10 15ZM10 7a3 3 0 1 0 0 6 3 3 0 0 0 0-6ZM15.657 5.404a.75.75 0 1 0-1.06-1.06l-1.061 1.06a.75.75 0 0 0 1.06 1.061l1.061-1.06ZM6.464 14.596a.75.75 0 1 0-1.06-1.06l-1.06 1.06a.75.75 0 0 0 1.06 1.06l1.06-1.06ZM18 10a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 18 10ZM5 10a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 5 10ZM14.596 15.657a.75.75 0 0 0 1.06-1.06l-1.06-1.061a.75.75 0 1 0-1.061 1.06l1.06 1.061ZM5.404 6.464a.75.75 0 0 0 1.06-1.06l-1.06-1.06a.75.75 0 1 0-1.061 1.06l1.06 1.06Z"
+		/>
+	</svg>
+	<!-- Moon icon (dark mode) -->
+	<svg
+		id="theme-dark-icon"
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 20 20"
+		fill="currentColor"
+		class="hidden size-5"
+	>
+		<path
+			fill-rule="evenodd"
+			d="M7.455 2.004a.75.75 0 0 1 .26.77 7 7 0 0 0 9.958 7.967.75.75 0 0 1 1.067.853A8.5 8.5 0 1 1 6.647 1.921a.75.75 0 0 1 .808.083Z"
+			clip-rule="evenodd"
+		/>
+	</svg>
+</button>
+
+<script is:inline>
+	// Initialize theme from localStorage or system preference
+	(function initTheme() {
+		const theme = localStorage.getItem("theme");
+		const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+		if (theme === "dark" || (!theme && prefersDark)) {
+			document.documentElement.classList.add("dark");
+		} else {
+			document.documentElement.classList.remove("dark");
+		}
+
+		updateIcons();
+	})();
+
+	function updateIcons() {
+		const isDark = document.documentElement.classList.contains("dark");
+		const lightIcon = document.getElementById("theme-light-icon");
+		const darkIcon = document.getElementById("theme-dark-icon");
+
+		if (lightIcon && darkIcon) {
+			// Show sun icon in dark mode (click to switch to light)
+			// Show moon icon in light mode (click to switch to dark)
+			if (isDark) {
+				lightIcon.classList.remove("hidden");
+				darkIcon.classList.add("hidden");
+			} else {
+				lightIcon.classList.add("hidden");
+				darkIcon.classList.remove("hidden");
+			}
+		}
+	}
+
+	// Toggle theme on button click
+	document.getElementById("theme-toggle")?.addEventListener("click", () => {
+		const isDark = document.documentElement.classList.toggle("dark");
+		localStorage.setItem("theme", isDark ? "dark" : "light");
+		updateIcons();
+	});
+
+	// Listen for system preference changes
+	window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+		if (!localStorage.getItem("theme")) {
+			if (e.matches) {
+				document.documentElement.classList.add("dark");
+			} else {
+				document.documentElement.classList.remove("dark");
+			}
+			updateIcons();
+		}
+	});
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -42,6 +42,17 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		<meta name="generator" content={Astro.generator} />
 		<meta name="color-scheme" content="light dark" />
 
+		<!-- Prevent flash of wrong theme -->
+		<script is:inline>
+			(function() {
+				const theme = localStorage.getItem("theme");
+				const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+				if (theme === "dark" || (!theme && prefersDark)) {
+					document.documentElement.classList.add("dark");
+				}
+			})();
+		</script>
+
 		<!-- Primary Meta Tags -->
 		<title>{title}</title>
 		<meta name="title" content={title} />
@@ -74,7 +85,7 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		></script>
 		<slot name="head" />
 	</head>
-	<body>
+	<body class="bg-white text-gray-900 transition-colors dark:bg-gray-900 dark:text-gray-100">
 		<!-- スキップリンク -->
 		<a href="#main-content" class="skip-link">
 			コンテンツにスキップ

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -1,10 +1,13 @@
 ---
 import { getCollection, render } from "astro:content";
 import Breadcrumb from "../../components/Breadcrumb.astro";
+import ShareButtons from "../../components/blog/ShareButtons.astro";
+import BackToTop from "../../components/ui/BackToTop.astro";
 import Tag from "../../components/ui/Tag.astro";
 import { SITE } from "../../config/site";
 import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
+import { formatReadingTime, getReadingTime } from "../../utils/reading-time";
 import { generateBreadcrumbSchema, stringifySchema } from "../../utils/schema";
 
 export async function getStaticPaths() {
@@ -18,6 +21,8 @@ export async function getStaticPaths() {
 const { post } = Astro.props;
 const { Content } = await render(post);
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const readingTime = getReadingTime(post.body || "");
+const readingTimeText = formatReadingTime(readingTime);
 const publishedTime = post.data.date.toISOString();
 const modifiedTime = post.data.updatedDate
 	? post.data.updatedDate.toISOString()
@@ -92,6 +97,7 @@ const siteUrl = Astro.site?.href || SITE.url;
             )
           }
         </time>
+        <span class="text-sm">{readingTimeText}</span>
         {
           post.data.tags && post.data.tags.length > 0 && (
             <div class="flex flex-wrap gap-2">
@@ -107,7 +113,12 @@ const siteUrl = Astro.site?.href || SITE.url;
     <article class="prose prose-lg max-w-none">
       <Content />
     </article>
+
+    <div class="mt-12 border-t border-gray-200 pt-8">
+      <ShareButtons url={canonicalURL.href} title={post.data.title} />
+    </div>
   </main>
+  <BackToTop />
 </Layout>
 
 <script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,9 +3,40 @@
 @import "@fontsource/shippori-mincho/500.css";
 @import "@fontsource/shippori-mincho/700.css";
 
-/* プライマリカラー */
+/* テーマカラー - ライトモード */
 :root {
 	--primary-color: #4f46e5;
+	--bg-primary: #ffffff;
+	--bg-secondary: #f8fafc;
+	--bg-tertiary: #f1f5f9;
+	--text-primary: #1a1a1a;
+	--text-secondary: #4b5563;
+	--text-muted: #9ca3af;
+	--border-color: #e2e8f0;
+	--link-color: #2563eb;
+	--link-hover-color: #1d4ed8;
+	--blockquote-bg: #eff6ff;
+	--blockquote-border: #3b82f6;
+	--code-bg: #f1f5f9;
+	--code-text: #1e293b;
+}
+
+/* テーマカラー - ダークモード */
+:root.dark {
+	--primary-color: #818cf8;
+	--bg-primary: #0f172a;
+	--bg-secondary: #1e293b;
+	--bg-tertiary: #334155;
+	--text-primary: #f1f5f9;
+	--text-secondary: #cbd5e1;
+	--text-muted: #64748b;
+	--border-color: #334155;
+	--link-color: #60a5fa;
+	--link-hover-color: #93c5fd;
+	--blockquote-bg: #1e3a5f;
+	--blockquote-border: #3b82f6;
+	--code-bg: #1e293b;
+	--code-text: #e2e8f0;
 }
 
 /* フォーカス表示の強化 */
@@ -67,12 +98,12 @@
 
 /* Inline code */
 .prose :not(pre) > code {
-	background: #f1f5f9;
+	background: var(--code-bg);
 	padding: 0.125rem 0.375rem;
 	border-radius: 0.25rem;
 	font-size: 0.875em;
 	font-weight: 500;
-	color: #1e293b;
+	color: var(--code-text);
 }
 
 /* Better heading anchors */
@@ -84,8 +115,8 @@
 
 /* Blockquote styling */
 .prose blockquote {
-	border-left-color: #3b82f6;
-	background: #eff6ff;
+	border-left-color: var(--blockquote-border);
+	background: var(--blockquote-bg);
 	padding: 1rem;
 	border-radius: 0 0.5rem 0.5rem 0;
 	font-style: normal;
@@ -102,18 +133,18 @@
 }
 
 .prose th {
-	background: #f8fafc;
+	background: var(--bg-secondary);
 	font-weight: 600;
 }
 
 .prose th,
 .prose td {
-	border: 1px solid #e2e8f0;
+	border: 1px solid var(--border-color);
 	padding: 0.75rem;
 }
 
 .prose tr:hover {
-	background: #f8fafc;
+	background: var(--bg-secondary);
 }
 
 /* Task list styling */
@@ -141,11 +172,11 @@
 
 /* Link styling */
 .prose a {
-	color: #2563eb;
+	color: var(--link-color);
 	text-decoration: underline;
 	text-underline-offset: 2px;
 }
 
 .prose a:hover {
-	color: #1d4ed8;
+	color: var(--link-hover-color);
 }

--- a/src/utils/reading-time.ts
+++ b/src/utils/reading-time.ts
@@ -1,0 +1,33 @@
+/**
+ * Calculate reading time for content
+ * @param content - The text content to analyze
+ * @param wordsPerMinute - Reading speed (default: 400 for Japanese)
+ * @returns Reading time in minutes
+ */
+export const getReadingTime = (
+	content: string,
+	wordsPerMinute = 400,
+): number => {
+	// For Japanese text, count characters instead of words
+	// Remove HTML tags, code blocks, and whitespace
+	const cleanContent = content
+		.replace(/<[^>]*>/g, "") // Remove HTML tags
+		.replace(/```[\s\S]*?```/g, "") // Remove code blocks
+		.replace(/`[^`]*`/g, "") // Remove inline code
+		.replace(/\s+/g, ""); // Remove whitespace
+
+	// Calculate based on character count for Japanese
+	const characters = cleanContent.length;
+	const minutes = Math.ceil(characters / wordsPerMinute);
+
+	return Math.max(1, minutes);
+};
+
+/**
+ * Format reading time as a string
+ * @param minutes - Reading time in minutes
+ * @returns Formatted string like "約3分で読了"
+ */
+export const formatReadingTime = (minutes: number): string => {
+	return `約${minutes}分で読了`;
+};


### PR DESCRIPTION
## Summary
- Add reading time calculation for blog posts
- Add share buttons (X, Bluesky, LINE, copy URL)
- Add back to top floating button
- Include dark mode support improvements

## Test plan
- [ ] Verify reading time displays correctly
- [ ] Test share buttons functionality
- [ ] Verify back to top button appears on scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark/light theme toggle with system preference detection
  * Introduced reading time estimates for blog articles
  * Added social sharing buttons for blog posts (X/Twitter, Bluesky, LINE)
  * Added "back to top" button for improved page navigation

* **Style**
  * Extended dark mode styling across site components
  * Implemented consistent CSS variable-based theming system

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->