### PR TITLE
feat(seo): add post navigation and related posts components

### DIFF
--- a/src/components/PostNavigation.astro
+++ b/src/components/PostNavigation.astro
@@ -1,0 +1,55 @@
+---
+interface NavPost {
+	id: string;
+	title: string;
+}
+
+interface Props {
+	prevPost?: NavPost;
+	nextPost?: NavPost;
+	basePath?: string;
+}
+
+const { prevPost, nextPost, basePath = "/blog" } = Astro.props;
+
+// 両方ない場合は何も表示しない
+if (!prevPost && !nextPost) {
+	return null;
+}
+---
+
+<nav
+  class="mt-12 border-t border-[var(--border-color)] pt-8"
+  aria-label="前後の記事"
+>
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+    {
+      prevPost ? (
+        <a
+          href={`${basePath}/${prevPost.id}`}
+          class="group flex flex-col rounded-lg border border-[var(--border-color)] p-4 transition-colors hover:border-[var(--primary-color)] hover:bg-[var(--bg-secondary)]"
+        >
+          <span class="mb-1 text-sm text-[var(--text-muted)]">← 前の記事</span>
+          <span class="font-medium text-[var(--text-primary)] transition-colors group-hover:text-[var(--primary-color)]">
+            {prevPost.title}
+          </span>
+        </a>
+      ) : (
+        <div />
+      )
+    }
+    {
+      nextPost ? (
+        <a
+          href={`${basePath}/${nextPost.id}`}
+          class="group flex flex-col rounded-lg border border-[var(--border-color)] p-4 text-right transition-colors hover:border-[var(--primary-color)] hover:bg-[var(--bg-secondary)] sm:col-start-2"
+        >
+          <span class="mb-1 text-sm text-[var(--text-muted)]">次の記事 →</span>
+          <span class="font-medium text-[var(--text-primary)] transition-colors group-hover:text-[var(--primary-color)]">
+            {nextPost.title}
+          </span>
+        </a>
+      ) : null
+    }
+  </div>
+</nav>

--- a/src/components/PostNavigation.astro
+++ b/src/components/PostNavigation.astro
@@ -34,9 +34,7 @@ if (!prevPost && !nextPost) {
             {prevPost.title}
           </span>
         </a>
-      ) : (
-        <div />
-      )
+      ) : null
     }
     {
       nextPost ? (

--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -1,0 +1,46 @@
+---
+import type { CollectionEntry } from "astro:content";
+import { formatDate } from "../utils/date";
+
+interface Props {
+	posts: CollectionEntry<"blog">[];
+	basePath?: string;
+}
+
+const { posts, basePath = "/blog" } = Astro.props;
+
+// 関連記事がない場合は何も表示しない
+if (posts.length === 0) {
+	return null;
+}
+---
+
+<aside class="mt-12 border-t border-[var(--border-color)] pt-8">
+  <h2 class="mb-6 text-xl font-bold text-[var(--text-primary)]">関連記事</h2>
+  <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    {
+      posts.map((post) => (
+        <a
+          href={`${basePath}/${post.id}`}
+          class="group flex flex-col rounded-lg border border-[var(--border-color)] p-4 transition-colors hover:border-[var(--primary-color)] hover:bg-[var(--bg-secondary)]"
+        >
+          <span class="mb-2 text-sm text-[var(--text-muted)]">
+            {formatDate(post.data.date)}
+          </span>
+          <span class="mb-2 font-medium text-[var(--text-primary)] transition-colors group-hover:text-[var(--primary-color)]">
+            {post.data.title}
+          </span>
+          {post.data.tags && post.data.tags.length > 0 && (
+            <div class="mt-auto flex flex-wrap gap-1">
+              {post.data.tags.slice(0, 2).map((tag) => (
+                <span class="rounded bg-[var(--bg-tertiary)] px-2 py-0.5 text-xs text-[var(--text-secondary)]">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </a>
+      ))
+    }
+  </div>
+</aside>

--- a/src/pages/blog/[id].astro
+++ b/src/pages/blog/[id].astro
@@ -1,7 +1,10 @@
 ---
+import type { CollectionEntry } from "astro:content";
 import { getCollection, render } from "astro:content";
 import Breadcrumb from "../../components/Breadcrumb.astro";
 import ShareButtons from "../../components/blog/ShareButtons.astro";
+import PostNavigation from "../../components/PostNavigation.astro";
+import RelatedPosts from "../../components/RelatedPosts.astro";
 import BackToTop from "../../components/ui/BackToTop.astro";
 import Tag from "../../components/ui/Tag.astro";
 import { SITE } from "../../config/site";
@@ -12,13 +15,40 @@ import { generateBreadcrumbSchema, stringifySchema } from "../../utils/schema";
 
 export async function getStaticPaths() {
 	const blogPosts = await getCollection("blog");
-	return blogPosts.map((post) => ({
-		params: { id: post.id },
-		props: { post },
-	}));
+	// 公開日でソート（新しい順）
+	const sortedPosts = blogPosts.sort(
+		(a, b) => b.data.date.getTime() - a.data.date.getTime(),
+	);
+
+	return sortedPosts.map((post, index) => {
+		// 前後の記事（時系列順: prev=古い、next=新しい）
+		const prevPost = sortedPosts[index + 1];
+		const nextPost = sortedPosts[index - 1];
+
+		// 関連記事（同じタグを持つ記事、最大3件）
+		const currentTags = post.data.tags || [];
+		const relatedPosts = sortedPosts
+			.filter((p) => p.id !== post.id)
+			.filter((p) => p.data.tags?.some((t: string) => currentTags.includes(t)))
+			.slice(0, 3);
+
+		return {
+			params: { id: post.id },
+			props: {
+				post,
+				prevPost: prevPost
+					? { id: prevPost.id, title: prevPost.data.title }
+					: undefined,
+				nextPost: nextPost
+					? { id: nextPost.id, title: nextPost.data.title }
+					: undefined,
+				relatedPosts,
+			},
+		};
+	});
 }
 
-const { post } = Astro.props;
+const { post, prevPost, nextPost, relatedPosts } = Astro.props;
 const { Content } = await render(post);
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const readingTime = getReadingTime(post.body || "");
@@ -117,6 +147,10 @@ const siteUrl = Astro.site?.href || SITE.url;
     <div class="mt-12 border-t border-gray-200 pt-8">
       <ShareButtons url={canonicalURL.href} title={post.data.title} />
     </div>
+
+    <PostNavigation prevPost={prevPost} nextPost={nextPost} />
+
+    <RelatedPosts posts={relatedPosts} />
   </main>
   <BackToTop />
 </Layout>


### PR DESCRIPTION
- Add PostNavigation.astro for prev/next article navigation
- Add RelatedPosts.astro for tag-based related articles
- Integrate both components into blog/[id].astro
- Improve internal linking for SEO and user experience

Closes TA-60

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added post navigation: Blog posts now display previous and next post links for seamless browsing
  * Added related posts section: Blog posts now show related content based on shared tags (up to 3 posts)
  * Enhanced blog reading experience with responsive design across all screen sizes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->