### PR TITLE
refactor: add centralized type definitions

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,85 @@
+/**
+ * Type definitions for the portfolio site
+ * コンテンツコレクションと共通Props型の定義
+ */
+
+import type { CollectionEntry } from "astro:content";
+
+// =============================================================================
+// Content Collection Types
+// =============================================================================
+
+export type BlogPost = CollectionEntry<"blog">;
+export type Work = CollectionEntry<"works">;
+export type Book = CollectionEntry<"books">;
+export type About = CollectionEntry<"about">;
+export type Talk = CollectionEntry<"talks">;
+export type ZennArticle = CollectionEntry<"zenn">;
+export type NoteArticle = CollectionEntry<"note">;
+export type PodcastEpisode = CollectionEntry<"podcast">;
+
+// =============================================================================
+// SEO Types
+// =============================================================================
+
+export interface SEOProps {
+	title: string;
+	description: string;
+	ogType?: "website" | "article" | "book" | "profile";
+	ogImage?: string;
+	ogImageAlt?: string;
+	canonicalURL?: string;
+	noindex?: boolean;
+}
+
+// =============================================================================
+// Navigation Types
+// =============================================================================
+
+export interface NavLink {
+	href: string;
+	text: string;
+	external?: boolean;
+}
+
+export interface BreadcrumbItem {
+	label: string;
+	href?: string;
+}
+
+// =============================================================================
+// Content Card Types
+// =============================================================================
+
+export interface CardProps {
+	title: string;
+	description?: string;
+	href: string;
+	date?: Date;
+	tags?: string[];
+	image?: ImageMetadata;
+}
+
+// =============================================================================
+// Utility Types
+// =============================================================================
+
+/** Image metadata from Astro's image optimization */
+export interface ImageMetadata {
+	src: string;
+	width: number;
+	height: number;
+	format: string;
+}
+
+/** Date range for works/projects */
+export interface DateRange {
+	start: Date;
+	end?: Date;
+}
+
+/** Reading status for books */
+export type ReadingStatus = "read" | "reading" | "stacked";
+
+/** External article source */
+export type ExternalSource = "Zenn" | "Note" | "Podcast";


### PR DESCRIPTION
Create src/types/index.ts with:
- Content collection type aliases (BlogPost, Work, Book, etc.)
- SEO props interface
- Navigation types (NavLink, BreadcrumbItem)
- Content card props
- Utility types (DateRange, ReadingStatus, ExternalSource)

Closes TA-46

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established centralized type definitions for portfolio content organization and metadata across the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->