### PR TITLE
refactor: improve content schema consistency

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,6 +2,20 @@ import { defineCollection, z } from "astro:content";
 import { glob } from "astro/loaders";
 import { createRSSLoader, type RSSSource } from "./utils/rss-loader";
 
+// =============================================================================
+// Common Schema Parts - 共通スキーマパーツ
+// =============================================================================
+
+/** Tags schema - consistent across collections */
+const tagsSchema = z.array(z.string()).optional();
+
+/** Excerpt schema - short description */
+const excerptSchema = z.string();
+
+// =============================================================================
+// Content Collections
+// =============================================================================
+
 // Aboutコレクション
 const about = defineCollection({
 	loader: glob({ pattern: "**/*.md", base: "./src/content/about" }),
@@ -21,10 +35,10 @@ const works = defineCollection({
 		z.object({
 			title: z.string(),
 			coverImage: image(),
-			keywords: z.array(z.string()),
+			tags: z.array(z.string()),
 			startDate: z.coerce.date(),
 			endDate: z.coerce.date().optional(),
-			excerpt: z.string(),
+			excerpt: excerptSchema,
 		}),
 });
 
@@ -40,8 +54,8 @@ const books = defineCollection({
 			finishedDate: z.coerce.date().optional(),
 			rating: z.number().min(1).max(5).optional(),
 			category: z.string().optional(),
-			tags: z.array(z.string()),
-			excerpt: z.string(),
+			tags: z.array(z.string()), // Required for books
+			excerpt: excerptSchema,
 		}),
 });
 
@@ -52,8 +66,8 @@ const blog = defineCollection({
 		title: z.string(),
 		date: z.coerce.date(),
 		updatedDate: z.coerce.date().optional(),
-		excerpt: z.string(),
-		tags: z.array(z.string()).optional(),
+		excerpt: excerptSchema,
+		tags: tagsSchema,
 	}),
 });
 

--- a/src/content/works/sample-project.md
+++ b/src/content/works/sample-project.md
@@ -1,7 +1,7 @@
 ---
 title: "サンプルプロジェクト"
 coverImage: "../../../public/favicon.svg"
-keywords: ["Astro", "TypeScript", "Tailwind CSS"]
+tags: ["Astro", "TypeScript", "Tailwind CSS"]
 startDate: 2024-01-01
 endDate: 2024-12-31
 excerpt: "これはサンプルのポートフォリオプロジェクトです。"

--- a/src/pages/works/[id].astro
+++ b/src/pages/works/[id].astro
@@ -29,7 +29,7 @@ const workSchema = {
 	name: work.data.title,
 	description: work.data.excerpt,
 	image: ogImageURL.href,
-	keywords: work.data.keywords.join(", "),
+	keywords: work.data.tags.join(", "),
 	dateCreated: createdTime,
 	dateModified: modifiedTime,
 	author: {
@@ -88,9 +88,9 @@ const siteUrl = Astro.site?.href || SITE.url;
       </p>
       <div class="mb-6 flex flex-wrap gap-2">
         {
-          work.data.keywords.map((keyword) => (
+          work.data.tags.map((tag) => (
             <span class="rounded-full bg-gray-100 px-4 py-2 text-sm">
-              {keyword}
+              {tag}
             </span>
           ))
         }

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -35,9 +35,9 @@ const sortedWorks = works.sort(
               <h2 class="mb-2 text-xl font-bold">{work.data.title}</h2>
               <p class="mb-3 text-sm text-gray-600">{work.data.excerpt}</p>
               <div class="flex flex-wrap gap-2">
-                {work.data.keywords.map((keyword) => (
+                {work.data.tags.map((tag) => (
                   <span class="rounded bg-gray-100 px-2 py-1 text-xs">
-                    {keyword}
+                    {tag}
                   </span>
                 ))}
               </div>


### PR DESCRIPTION
- Add common schema parts (tagsSchema, excerptSchema)
- Rename works.keywords to works.tags for consistency
- Use shared excerptSchema across collections
- Update works content and pages to use tags

Closes TA-48

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>