### PR TITLE
refactor: add content collection utility functions

### DIFF
--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -23,6 +23,7 @@ export const createStaticPaths = <T extends CollectionKey>(collection: T) => {
 
 /**
  * Sort content items by date (newest first)
+ * Safely handles missing or invalid date fields
  * @param items - Array of content items with date field
  * @param dateField - The field name containing the date
  * @returns Sorted array
@@ -32,9 +33,12 @@ export const sortByDate = <T extends { data: Record<string, unknown> }>(
 	dateField = "date",
 ): T[] => {
 	return [...items].sort((a, b) => {
-		const dateA = a.data[dateField] as Date;
-		const dateB = b.data[dateField] as Date;
-		return dateB.getTime() - dateA.getTime();
+		const dateA = a.data[dateField];
+		const dateB = b.data[dateField];
+		// Safely get timestamp, treating missing/invalid dates as 0
+		const timeA = dateA instanceof Date ? dateA.getTime() : 0;
+		const timeB = dateB instanceof Date ? dateB.getTime() : 0;
+		return timeB - timeA;
 	});
 };
 

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,0 +1,77 @@
+/**
+ * Content collection utilities
+ * コンテンツコレクション用のヘルパー関数
+ */
+
+import type { CollectionKey } from "astro:content";
+import { getCollection } from "astro:content";
+
+/**
+ * Create getStaticPaths function for collection detail pages
+ * @param collection - The collection name
+ * @returns getStaticPaths function
+ */
+export const createStaticPaths = <T extends CollectionKey>(collection: T) => {
+	return async () => {
+		const items = await getCollection(collection);
+		return items.map((item) => ({
+			params: { id: item.id },
+			props: { item },
+		}));
+	};
+};
+
+/**
+ * Sort content items by date (newest first)
+ * @param items - Array of content items with date field
+ * @param dateField - The field name containing the date
+ * @returns Sorted array
+ */
+export const sortByDate = <T extends { data: Record<string, unknown> }>(
+	items: T[],
+	dateField = "date",
+): T[] => {
+	return [...items].sort((a, b) => {
+		const dateA = a.data[dateField] as Date;
+		const dateB = b.data[dateField] as Date;
+		return dateB.getTime() - dateA.getTime();
+	});
+};
+
+/**
+ * Filter content items by tag
+ * @param items - Array of content items
+ * @param tag - Tag to filter by
+ * @returns Filtered array
+ */
+export const filterByTag = <
+	T extends { data: { tags?: string[] } },
+>(
+	items: T[],
+	tag: string,
+): T[] => {
+	return items.filter((item) => item.data.tags?.includes(tag));
+};
+
+/**
+ * Get related items based on shared tags
+ * @param currentItem - The current item
+ * @param allItems - All items in the collection
+ * @param limit - Maximum number of related items
+ * @returns Array of related items
+ */
+export const getRelatedItems = <
+	T extends { id: string; data: { tags?: string[] } },
+>(
+	currentItem: T,
+	allItems: T[],
+	limit = 3,
+): T[] => {
+	const currentTags = currentItem.data.tags || [];
+	if (currentTags.length === 0) return [];
+
+	return allItems
+		.filter((item) => item.id !== currentItem.id)
+		.filter((item) => item.data.tags?.some((tag) => currentTags.includes(tag)))
+		.slice(0, limit);
+};


### PR DESCRIPTION
Create src/utils/content.ts with:
- createStaticPaths: Factory for getStaticPaths functions
- sortByDate: Sort items by date field
- filterByTag: Filter items by tag
- getRelatedItems: Find related items based on shared tags

These utilities reduce boilerplate in content pages.

Closes TA-49

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>