### PR TITLE
feat(search): add global search modal with Pagefind integration

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 // ヘッダーコンポーネント
 import Logo from "./Logo.astro";
+import SearchModal from "./SearchModal.astro";
 import ThemeToggle from "./ui/ThemeToggle.astro";
 
 const navLinks = [
@@ -39,11 +40,35 @@ const currentPath = Astro.url.pathname;
           ))
         }
       </ul>
+      <!-- 検索ボタン -->
+      <button
+        type="button"
+        id="desktop-search-button"
+        class="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm text-gray-500 transition-colors hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:bg-gray-700"
+        aria-label="サイト内検索を開く"
+      >
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+        </svg>
+        <span class="hidden lg:inline">検索</span>
+        <kbd class="hidden rounded border border-gray-300 bg-white px-1.5 py-0.5 font-mono text-xs dark:border-gray-600 dark:bg-gray-900 lg:inline">⌘K</kbd>
+      </button>
       <ThemeToggle />
     </div>
 
-    <!-- モバイル: テーマ切り替え + ハンバーガー -->
+    <!-- モバイル: 検索 + テーマ切り替え + ハンバーガー -->
     <div class="flex items-center gap-2 md:hidden">
+      <!-- モバイル検索ボタン -->
+      <button
+        type="button"
+        id="mobile-search-button"
+        class="flex h-10 w-10 items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
+        aria-label="サイト内検索を開く"
+      >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+        </svg>
+      </button>
       <ThemeToggle />
       <button
         type="button"
@@ -109,6 +134,9 @@ const currentPath = Astro.url.pathname;
   </div>
 </header>
 
+<!-- 検索モーダル -->
+<SearchModal />
+
 <style>
   [aria-current="page"] {
     font-weight: 600;
@@ -155,4 +183,17 @@ const currentPath = Astro.url.pathname;
       }
     });
   }
+
+  // 検索ボタンのイベントハンドラ
+  const desktopSearchBtn = document.getElementById("desktop-search-button");
+  const mobileSearchBtn = document.getElementById("mobile-search-button");
+
+  function handleSearchClick() {
+    if (typeof (window as Window & { openGlobalSearch?: () => void }).openGlobalSearch === "function") {
+      (window as Window & { openGlobalSearch: () => void }).openGlobalSearch();
+    }
+  }
+
+  desktopSearchBtn?.addEventListener("click", handleSearchClick);
+  mobileSearchBtn?.addEventListener("click", handleSearchClick);
 </script>

--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -1,0 +1,295 @@
+---
+// グローバル検索モーダルコンポーネント
+// Pagefind UIを使用してサイト全体を検索
+---
+
+<div
+  id="search-modal-overlay"
+  class="fixed inset-0 z-[100] hidden bg-black/50 backdrop-blur-sm"
+  aria-hidden="true"
+>
+  <div
+    id="search-modal"
+    class="mx-auto mt-[10vh] max-h-[80vh] w-full max-w-2xl overflow-hidden rounded-xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+    role="dialog"
+    aria-modal="true"
+    aria-label="サイト内検索"
+  >
+    <!-- ヘッダー -->
+    <div class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+      <div class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+        </svg>
+        <span>サイト内検索</span>
+      </div>
+      <button
+        id="search-modal-close"
+        type="button"
+        class="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
+        aria-label="検索を閉じる"
+      >
+        <kbd class="rounded border border-gray-300 bg-gray-100 px-1.5 py-0.5 font-mono text-xs dark:border-gray-600 dark:bg-gray-800">Esc</kbd>
+      </button>
+    </div>
+
+    <!-- 検索UI -->
+    <div class="overflow-y-auto p-4" style="max-height: calc(80vh - 120px);">
+      <div id="global-pagefind-search" class="pagefind-search"></div>
+    </div>
+
+    <!-- フッター -->
+    <div class="flex items-center justify-between border-t border-gray-200 px-4 py-2 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
+      <div class="flex items-center gap-4">
+        <span class="flex items-center gap-1">
+          <kbd class="rounded border border-gray-300 bg-gray-100 px-1 py-0.5 font-mono dark:border-gray-600 dark:bg-gray-800">↑</kbd>
+          <kbd class="rounded border border-gray-300 bg-gray-100 px-1 py-0.5 font-mono dark:border-gray-600 dark:bg-gray-800">↓</kbd>
+          で移動
+        </span>
+        <span class="flex items-center gap-1">
+          <kbd class="rounded border border-gray-300 bg-gray-100 px-1 py-0.5 font-mono dark:border-gray-600 dark:bg-gray-800">Enter</kbd>
+          で開く
+        </span>
+      </div>
+      <span>Powered by Pagefind</span>
+    </div>
+  </div>
+</div>
+
+<style is:global>
+  /* Pagefind UIのスタイルオーバーライド（モーダル用） */
+  #global-pagefind-search .pagefind-ui__search-input {
+    width: 100%;
+    border-radius: 0.5rem;
+    border: 1px solid #d1d5db;
+    background-color: white;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    outline: none;
+  }
+
+  #global-pagefind-search .pagefind-ui__search-input:focus {
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+  }
+
+  :root.dark #global-pagefind-search .pagefind-ui__search-input {
+    border-color: #4b5563;
+    background-color: #1f2937;
+    color: white;
+  }
+
+  #global-pagefind-search .pagefind-ui__search-clear {
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    border-radius: 0.375rem;
+    padding: 0.25rem;
+    color: #9ca3af;
+  }
+
+  #global-pagefind-search .pagefind-ui__search-clear:hover {
+    color: #4b5563;
+  }
+
+  :root.dark #global-pagefind-search .pagefind-ui__search-clear:hover {
+    color: #d1d5db;
+  }
+
+  #global-pagefind-search .pagefind-ui__results {
+    margin-top: 1rem;
+  }
+
+  #global-pagefind-search .pagefind-ui__result {
+    margin-bottom: 0.75rem;
+    border-radius: 0.5rem;
+    border: 1px solid #e5e7eb;
+    padding: 0.75rem;
+    transition: all 0.15s ease;
+  }
+
+  #global-pagefind-search .pagefind-ui__result:hover {
+    border-color: #60a5fa;
+    background-color: #eff6ff;
+  }
+
+  :root.dark #global-pagefind-search .pagefind-ui__result {
+    border-color: #374151;
+  }
+
+  :root.dark #global-pagefind-search .pagefind-ui__result:hover {
+    border-color: #3b82f6;
+    background-color: #1f2937;
+  }
+
+  #global-pagefind-search .pagefind-ui__result-link {
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: #2563eb;
+    text-decoration: none;
+  }
+
+  #global-pagefind-search .pagefind-ui__result-link:hover {
+    color: #1d4ed8;
+  }
+
+  :root.dark #global-pagefind-search .pagefind-ui__result-link {
+    color: #60a5fa;
+  }
+
+  #global-pagefind-search .pagefind-ui__result-excerpt {
+    margin-top: 0.25rem;
+    font-size: 0.875rem;
+    color: #4b5563;
+  }
+
+  :root.dark #global-pagefind-search .pagefind-ui__result-excerpt {
+    color: #9ca3af;
+  }
+
+  #global-pagefind-search .pagefind-ui__result-excerpt mark {
+    border-radius: 0.125rem;
+    background-color: #fef08a;
+    padding: 0 0.125rem;
+    font-weight: 500;
+    color: #111827;
+  }
+
+  :root.dark #global-pagefind-search .pagefind-ui__result-excerpt mark {
+    background-color: rgba(234, 179, 8, 0.3);
+    color: white;
+  }
+
+  #global-pagefind-search .pagefind-ui__message {
+    text-align: center;
+    color: #6b7280;
+  }
+
+  :root.dark #global-pagefind-search .pagefind-ui__message {
+    color: #9ca3af;
+  }
+
+  #global-pagefind-search .pagefind-ui__button {
+    margin-top: 1rem;
+    width: 100%;
+    border-radius: 0.5rem;
+    border: 1px solid #d1d5db;
+    background-color: white;
+    padding: 0.5rem 1rem;
+    color: #374151;
+    transition: background-color 0.15s ease;
+  }
+
+  #global-pagefind-search .pagefind-ui__button:hover {
+    background-color: #f9fafb;
+  }
+
+  :root.dark #global-pagefind-search .pagefind-ui__button {
+    border-color: #4b5563;
+    background-color: #1f2937;
+    color: #d1d5db;
+  }
+
+  :root.dark #global-pagefind-search .pagefind-ui__button:hover {
+    background-color: #374151;
+  }
+</style>
+
+<script is:inline>
+  (function() {
+    const overlay = document.getElementById("search-modal-overlay");
+    const closeBtn = document.getElementById("search-modal-close");
+    let pagefindInitialized = false;
+
+    async function initPagefind() {
+      if (pagefindInitialized) return;
+
+      try {
+        const { PagefindUI } = await import("/pagefind/pagefind-ui.js");
+        const searchElement = document.getElementById("global-pagefind-search");
+        if (searchElement) {
+          new PagefindUI({
+            element: searchElement,
+            showSubResults: true,
+            autofocus: true,
+            translations: {
+              placeholder: "記事やページを検索...",
+              clear_search: "クリア",
+              load_more: "さらに読み込む",
+              search_label: "このサイトを検索",
+              filters_label: "フィルター",
+              zero_results: "「[SEARCH_TERM]」の検索結果が見つかりませんでした",
+              many_results: "「[SEARCH_TERM]」の検索結果: [COUNT]件",
+              one_result: "「[SEARCH_TERM]」の検索結果: [COUNT]件",
+            },
+          });
+          pagefindInitialized = true;
+        }
+      } catch (e) {
+        console.error("Pagefind UIの読み込みに失敗しました", e);
+        const searchElement = document.getElementById("global-pagefind-search");
+        if (searchElement) {
+          searchElement.innerHTML = '<p style="text-align: center; color: #6b7280; padding: 2rem 0;">検索機能はビルド後に利用可能になります。</p>';
+        }
+      }
+    }
+
+    function openSearch() {
+      if (!overlay) return;
+      overlay.classList.remove("hidden");
+      overlay.setAttribute("aria-hidden", "false");
+      document.body.style.overflow = "hidden";
+      initPagefind();
+
+      // 検索入力欄にフォーカス
+      setTimeout(function() {
+        const input = document.querySelector("#global-pagefind-search input");
+        if (input) input.focus();
+      }, 100);
+    }
+
+    function closeSearch() {
+      if (!overlay) return;
+      overlay.classList.add("hidden");
+      overlay.setAttribute("aria-hidden", "true");
+      document.body.style.overflow = "";
+    }
+
+    // 閉じるボタン
+    if (closeBtn) {
+      closeBtn.addEventListener("click", closeSearch);
+    }
+
+    // オーバーレイクリックで閉じる
+    if (overlay) {
+      overlay.addEventListener("click", function(e) {
+        if (e.target === overlay) {
+          closeSearch();
+        }
+      });
+    }
+
+    // Escキーで閉じる
+    document.addEventListener("keydown", function(e) {
+      if (e.key === "Escape" && overlay && !overlay.classList.contains("hidden")) {
+        closeSearch();
+      }
+    });
+
+    // Cmd/Ctrl+K で検索を開く
+    document.addEventListener("keydown", function(e) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        if (overlay && overlay.classList.contains("hidden")) {
+          openSearch();
+        } else {
+          closeSearch();
+        }
+      }
+    });
+
+    // グローバル関数として公開（ヘッダーボタンから呼び出し用）
+    window.openGlobalSearch = openSearch;
+  })();
+</script>


### PR DESCRIPTION
- Add SearchModal component with Pagefind UI
- Add search button to header (desktop and mobile)
- Implement Cmd/Ctrl+K keyboard shortcut
- Support dark mode styling for search results
- Fix Badge.astro type-only import issue

Closes TA-59

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>