### PR TITLE
feat(ux): add filtering and sorting to list pages

### DIFF
--- a/src/components/FilterSort.astro
+++ b/src/components/FilterSort.astro
@@ -67,7 +67,7 @@ const uniqueTags = [...new Set(tags)].sort();
   </div>
 </div>
 
-<style>
+<style is:global>
   .filter-tag.active {
     border-color: #3b82f6;
     background-color: #3b82f6;
@@ -78,6 +78,19 @@ const uniqueTags = [...new Set(tags)].sort();
     border-color: #60a5fa;
     background-color: #60a5fa;
     color: #1f2937;
+  }
+
+  /* Smooth filter transition */
+  [data-item] {
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  [data-item].filter-hidden {
+    opacity: 0;
+    transform: scale(0.95);
+    pointer-events: none;
+    position: absolute;
+    visibility: hidden;
   }
 </style>
 
@@ -137,14 +150,16 @@ const uniqueTags = [...new Set(tags)].sort();
           return 0;
         });
 
-        // Update visibility and order
+        // Update visibility with smooth transition
         items.forEach(function(item) {
-          item.style.display = "none";
-          item.style.order = "999";
+          if (!filteredItems.includes(item)) {
+            item.classList.add("filter-hidden");
+            item.style.order = "999";
+          }
         });
 
         filteredItems.forEach(function(item, index) {
-          item.style.display = "";
+          item.classList.remove("filter-hidden");
           item.style.order = String(index);
         });
 

--- a/src/components/FilterSort.astro
+++ b/src/components/FilterSort.astro
@@ -1,0 +1,178 @@
+---
+// フィルタリング・ソートコンポーネント
+// クライアントサイドでリストのフィルタ・ソートを行う
+
+interface Props {
+	tags: string[];
+	sortOptions?: { value: string; label: string }[];
+	containerId: string;
+}
+
+const {
+	tags,
+	sortOptions = [
+		{ value: "date-desc", label: "新しい順" },
+		{ value: "date-asc", label: "古い順" },
+		{ value: "title", label: "タイトル順" },
+	],
+	containerId,
+} = Astro.props;
+
+// 重複を排除してソート
+const uniqueTags = [...new Set(tags)].sort();
+---
+
+<div class="mb-8 space-y-4" data-filter-sort data-container={containerId}>
+  <!-- フィルター -->
+  {uniqueTags.length > 0 && (
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="text-sm font-medium text-gray-600 dark:text-gray-400">タグ:</span>
+      <button
+        type="button"
+        class="filter-tag active rounded-full border border-gray-300 px-3 py-1 text-sm transition-colors hover:border-blue-500 hover:text-blue-600 dark:border-gray-600 dark:hover:border-blue-400 dark:hover:text-blue-400"
+        data-tag="all"
+      >
+        すべて
+      </button>
+      {uniqueTags.map((tag) => (
+        <button
+          type="button"
+          class="filter-tag rounded-full border border-gray-300 px-3 py-1 text-sm transition-colors hover:border-blue-500 hover:text-blue-600 dark:border-gray-600 dark:hover:border-blue-400 dark:hover:text-blue-400"
+          data-tag={tag}
+        >
+          {tag}
+        </button>
+      ))}
+    </div>
+  )}
+
+  <!-- ソート -->
+  <div class="flex items-center gap-2">
+    <label for={`sort-${containerId}`} class="text-sm font-medium text-gray-600 dark:text-gray-400">
+      並び替え:
+    </label>
+    <select
+      id={`sort-${containerId}`}
+      class="sort-select rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+    >
+      {sortOptions.map((option) => (
+        <option value={option.value}>{option.label}</option>
+      ))}
+    </select>
+  </div>
+
+  <!-- 結果数表示 -->
+  <div class="text-sm text-gray-500 dark:text-gray-400">
+    <span class="result-count"></span>
+  </div>
+</div>
+
+<style>
+  .filter-tag.active {
+    border-color: #3b82f6;
+    background-color: #3b82f6;
+    color: white;
+  }
+
+  :root.dark .filter-tag.active {
+    border-color: #60a5fa;
+    background-color: #60a5fa;
+    color: #1f2937;
+  }
+</style>
+
+<script is:inline>
+  (function() {
+    document.querySelectorAll("[data-filter-sort]").forEach(function(filterComponent) {
+      const containerId = filterComponent.dataset.container;
+      const container = document.getElementById(containerId);
+      if (!container) return;
+
+      const items = Array.from(container.querySelectorAll("[data-item]"));
+      const filterTags = filterComponent.querySelectorAll(".filter-tag");
+      const sortSelect = filterComponent.querySelector(".sort-select");
+      const resultCount = filterComponent.querySelector(".result-count");
+
+      let currentTag = "all";
+      let currentSort = "date-desc";
+
+      function updateResultCount(count, total) {
+        if (resultCount) {
+          if (currentTag === "all") {
+            resultCount.textContent = total + "件を表示中";
+          } else {
+            resultCount.textContent = count + " / " + total + "件を表示中";
+          }
+        }
+      }
+
+      function filterAndSort() {
+        // Get sort value
+        if (sortSelect) {
+          currentSort = sortSelect.value;
+        }
+
+        // Filter
+        const filteredItems = items.filter(function(item) {
+          if (currentTag === "all") return true;
+          const itemTags = item.dataset.tags ? item.dataset.tags.split(",") : [];
+          return itemTags.includes(currentTag);
+        });
+
+        // Sort
+        filteredItems.sort(function(a, b) {
+          if (currentSort === "date-desc") {
+            const aDate = new Date(a.dataset.date || 0).getTime();
+            const bDate = new Date(b.dataset.date || 0).getTime();
+            return bDate - aDate;
+          } else if (currentSort === "date-asc") {
+            const aDate = new Date(a.dataset.date || 0).getTime();
+            const bDate = new Date(b.dataset.date || 0).getTime();
+            return aDate - bDate;
+          } else if (currentSort === "title") {
+            const aTitle = a.dataset.title || "";
+            const bTitle = b.dataset.title || "";
+            return aTitle.localeCompare(bTitle, "ja");
+          }
+          return 0;
+        });
+
+        // Update visibility and order
+        items.forEach(function(item) {
+          item.style.display = "none";
+          item.style.order = "999";
+        });
+
+        filteredItems.forEach(function(item, index) {
+          item.style.display = "";
+          item.style.order = String(index);
+        });
+
+        updateResultCount(filteredItems.length, items.length);
+      }
+
+      // Tag filter click handlers
+      filterTags.forEach(function(tag) {
+        tag.addEventListener("click", function() {
+          currentTag = tag.dataset.tag;
+
+          // Update active state
+          filterTags.forEach(function(t) {
+            t.classList.remove("active");
+          });
+          tag.classList.add("active");
+
+          filterAndSort();
+        });
+      });
+
+      // Sort change handler
+      if (sortSelect) {
+        sortSelect.addEventListener("change", filterAndSort);
+      }
+
+      // Initial display
+      filterAndSort();
+    });
+  })();
+</script>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,5 +1,7 @@
 ---
 import { getCollection } from "astro:content";
+import FilterSort from "../../components/FilterSort.astro";
+import Tag from "../../components/ui/Tag.astro";
 import { SITE } from "../../config/site";
 import Layout from "../../layouts/Layout.astro";
 import { formatDate } from "../../utils/date";
@@ -8,6 +10,9 @@ const blogPosts = await getCollection("blog");
 const sortedPosts = blogPosts.sort(
 	(a, b) => b.data.date.getTime() - a.data.date.getTime(),
 );
+
+// すべてのタグを収集
+const allTags = blogPosts.flatMap((post) => post.data.tags ?? []);
 ---
 
 <Layout
@@ -44,12 +49,21 @@ const sortedPosts = blogPosts.sort(
       </a>
     </div>
 
-    <div class="space-y-8">
+    <!-- フィルタリング・ソート -->
+    <FilterSort tags={allTags} containerId="blog-list" />
+
+    <div id="blog-list" class="flex flex-col space-y-8">
       {
         sortedPosts.map((post) => (
-          <article class="border-b border-gray-200 pb-8">
+          <article
+            class="border-b border-gray-200 pb-8 dark:border-gray-700"
+            data-item
+            data-tags={(post.data.tags ?? []).join(",")}
+            data-date={post.data.date.toISOString()}
+            data-title={post.data.title}
+          >
             <a href={`/blog/${post.id}`} class="group block">
-              <time class="mb-2 block text-sm text-gray-600">
+              <time class="mb-2 block text-sm text-gray-600 dark:text-gray-400">
                 {formatDate(post.data.date)}
                 {post.data.updatedDate && (
                   <span class="ml-2 text-xs">
@@ -57,10 +71,17 @@ const sortedPosts = blogPosts.sort(
                   </span>
                 )}
               </time>
-              <h2 class="mb-3 text-2xl font-bold group-hover:text-gray-600">
+              <h2 class="mb-3 text-2xl font-bold group-hover:text-gray-600 dark:group-hover:text-gray-300">
                 {post.data.title}
               </h2>
-              <p class="text-gray-700">{post.data.excerpt}</p>
+              <p class="mb-3 text-gray-700 dark:text-gray-300">{post.data.excerpt}</p>
+              {post.data.tags && post.data.tags.length > 0 && (
+                <div class="flex flex-wrap gap-2">
+                  {post.data.tags.map((tag) => (
+                    <Tag>{tag}</Tag>
+                  ))}
+                </div>
+              )}
             </a>
           </article>
         ))

--- a/src/pages/bookshelf/index.astro
+++ b/src/pages/bookshelf/index.astro
@@ -1,6 +1,7 @@
 ---
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
+import FilterSort from "../../components/FilterSort.astro";
 import Badge from "../../components/ui/Badge.astro";
 import Tag from "../../components/ui/Tag.astro";
 import { SITE } from "../../config/site";
@@ -14,6 +15,19 @@ const sortedBooks = [...books].sort((a, b) => {
 	const bTime = b.data.finishedDate?.getTime() ?? 0;
 	return bTime - aTime;
 });
+
+// すべてのタグを収集（カテゴリ + タグ）
+const allTags = books.flatMap((book) => [
+	...(book.data.category ? [book.data.category] : []),
+	...book.data.tags,
+]);
+
+// ステータスに基づくソートオプション
+const sortOptions = [
+	{ value: "date-desc", label: "読了日（新しい順）" },
+	{ value: "date-asc", label: "読了日（古い順）" },
+	{ value: "title", label: "タイトル順" },
+];
 ---
 
 <Layout
@@ -23,12 +37,24 @@ const sortedBooks = [...books].sort((a, b) => {
   <main class="mx-auto max-w-6xl px-6 py-12">
     <h1 class="mb-12 text-4xl font-bold">Bookshelf</h1>
 
-    <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+    <!-- フィルタリング・ソート -->
+    <FilterSort tags={allTags} sortOptions={sortOptions} containerId="bookshelf-list" />
+
+    <div id="bookshelf-list" class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
       {
-        sortedBooks.map((book) => (
+        sortedBooks.map((book) => {
+          const bookTags = [
+            ...(book.data.category ? [book.data.category] : []),
+            ...book.data.tags,
+          ];
+          return (
           <a
             href={`/bookshelf/${book.id}`}
-            class="group block overflow-hidden rounded-lg border border-gray-200 transition-shadow hover:shadow-lg"
+            class="group block overflow-hidden rounded-lg border border-gray-200 transition-shadow hover:shadow-lg dark:border-gray-700"
+            data-item
+            data-tags={bookTags.join(",")}
+            data-date={book.data.finishedDate?.toISOString() ?? ""}
+            data-title={book.data.title}
           >
             <div class="aspect-[3/4] overflow-hidden bg-gray-100">
               <Image
@@ -60,7 +86,7 @@ const sortedBooks = [...books].sort((a, b) => {
               )}
             </div>
           </a>
-        ))
+        );})
       }
     </div>
   </main>

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -1,6 +1,8 @@
 ---
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
+import FilterSort from "../../components/FilterSort.astro";
+import Tag from "../../components/ui/Tag.astro";
 import { SITE } from "../../config/site";
 import Layout from "../../layouts/Layout.astro";
 
@@ -8,6 +10,16 @@ const works = await getCollection("works");
 const sortedWorks = works.sort(
 	(a, b) => b.data.startDate.getTime() - a.data.startDate.getTime(),
 );
+
+// すべてのタグを収集
+const allTags = works.flatMap((work) => work.data.tags);
+
+// ソートオプション
+const sortOptions = [
+	{ value: "date-desc", label: "開始日（新しい順）" },
+	{ value: "date-asc", label: "開始日（古い順）" },
+	{ value: "title", label: "タイトル順" },
+];
 ---
 
 <Layout
@@ -17,12 +29,19 @@ const sortedWorks = works.sort(
   <main class="mx-auto max-w-6xl px-6 py-12">
     <h1 class="mb-12 text-4xl font-bold">Works</h1>
 
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <!-- フィルタリング・ソート -->
+    <FilterSort tags={allTags} sortOptions={sortOptions} containerId="works-list" />
+
+    <div id="works-list" class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
       {
         sortedWorks.map((work) => (
           <a
             href={`/works/${work.id}`}
-            class="group block overflow-hidden rounded-lg border border-gray-200 transition-shadow hover:shadow-lg"
+            class="group block overflow-hidden rounded-lg border border-gray-200 transition-shadow hover:shadow-lg dark:border-gray-700"
+            data-item
+            data-tags={work.data.tags.join(",")}
+            data-date={work.data.startDate.toISOString()}
+            data-title={work.data.title}
           >
             <div class="aspect-video overflow-hidden bg-gray-100">
               <Image
@@ -33,12 +52,10 @@ const sortedWorks = works.sort(
             </div>
             <div class="p-4">
               <h2 class="mb-2 text-xl font-bold">{work.data.title}</h2>
-              <p class="mb-3 text-sm text-gray-600">{work.data.excerpt}</p>
+              <p class="mb-3 text-sm text-gray-600 dark:text-gray-400">{work.data.excerpt}</p>
               <div class="flex flex-wrap gap-2">
                 {work.data.tags.map((tag) => (
-                  <span class="rounded bg-gray-100 px-2 py-1 text-xs">
-                    {tag}
-                  </span>
+                  <Tag>{tag}</Tag>
                 ))}
               </div>
             </div>


### PR DESCRIPTION
- Create FilterSort component for tag filtering and sorting
- Add tag filter and sort options to Blog page
- Add tag/category filter and sort options to Bookshelf page
- Add keyword filter and sort options to Works page
- Support client-side filtering with smooth transitions
- Include result count display

Closes TA-61

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added filtering and sorting controls across Blog, Bookshelf, and Works sections of the site
  * Filter displayed content by tags, with an "All" option to show all items
  * Sort results by date (newest or oldest first) or alphabetically by title
  * Real-time results counter displays the total number of items matching the current filter and sort selections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->