### PR TITLE
feat: add initial design file created with Pencil

### DIFF
--- a/design.pen
+++ b/design.pen
@@ -1,0 +1,7485 @@
+{
+  "version": "2.6",
+  "children": [
+    {
+      "type": "frame",
+      "id": "jQUpf",
+      "x": 0,
+      "y": 0,
+      "name": "Landing Page - Desktop",
+      "width": 1440,
+      "fill": "$bg-primary",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "3rI5l",
+          "name": "Header",
+          "width": "fill_container",
+          "fill": "$bg-surface",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-color"
+          },
+          "padding": [
+            16,
+            48
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "id": "OfTua",
+              "type": "ref",
+              "ref": "v08Ll",
+              "name": "headerLogo"
+            },
+            {
+              "type": "frame",
+              "id": "KlPdv",
+              "name": "Nav Links",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "zyFVZ",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Home",
+                  "name": "navHome"
+                },
+                {
+                  "id": "Y3oyg",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Works",
+                  "name": "navWorks"
+                },
+                {
+                  "id": "I4cKd",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Blog",
+                  "name": "navBlog"
+                },
+                {
+                  "id": "hhKj2",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Links",
+                  "name": "navLinks"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "3NGtL",
+          "name": "Hero Section",
+          "width": "fill_container",
+          "height": 700,
+          "fill": "$bg-primary",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": 32,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "uVoam",
+              "name": "Greeting",
+              "fill": "$bg-surface",
+              "cornerRadius": 4,
+              "stroke": {
+                "thickness": 1,
+                "fill": "$border-color"
+              },
+              "padding": [
+                8,
+                16
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "5kGWC",
+                  "name": "heroGreetingText",
+                  "fill": "$text-muted",
+                  "content": "Welcome to my portfolio",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal",
+                  "letterSpacing": 1
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "h1vRb",
+              "name": "Title",
+              "fill": "$text-primary",
+              "content": "ta93abe",
+              "lineHeight": 1,
+              "fontFamily": "Shippori Mincho",
+              "fontSize": 144,
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "Mm5eC",
+              "name": "Description",
+              "fill": "$text-secondary",
+              "content": "Software Engineer & Creative Developer",
+              "fontFamily": "Inter",
+              "fontSize": 24,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "YS7pi",
+              "name": "CTA Buttons",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "BaoIL",
+                  "type": "ref",
+                  "ref": "qIlVR",
+                  "name": "ctaPrimary"
+                },
+                {
+                  "id": "VSbDk",
+                  "type": "ref",
+                  "ref": "JJp9T",
+                  "name": "ctaSecondary"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "0hlj7",
+          "name": "Footer",
+          "width": "fill_container",
+          "fill": "$bg-gray",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-color"
+          },
+          "layout": "vertical",
+          "padding": 32,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "qgnCk",
+              "name": "footerText",
+              "fill": "$text-muted",
+              "content": "© 2024 ta93abe. All rights reserved.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "gsNyF",
+      "x": 0,
+      "y": 1200,
+      "name": "Design Tokens - Colors",
+      "width": 1600,
+      "fill": "#ffffff",
+      "layout": "vertical",
+      "gap": 48,
+      "padding": 48,
+      "children": [
+        {
+          "type": "text",
+          "id": "yOrd3",
+          "name": "colorTitle",
+          "fill": "$slate-900",
+          "content": "Tailwind CSS Color Palette",
+          "fontFamily": "Inter",
+          "fontSize": 48,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "j0smn",
+          "name": "colorSubtitle",
+          "fill": "$slate-500",
+          "content": "22 color families × 11 shades each = 242 colors",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "AI3yo",
+          "name": "Slate",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "uAAjR",
+              "name": "slateLabel",
+              "fill": "$slate-700",
+              "content": "Slate",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "JMh3B",
+              "name": "slateSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "wLKBu",
+                  "name": "s50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$slate-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "5QyYM",
+                  "name": "s100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$slate-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "RxGjj",
+                  "name": "s200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$slate-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "RgbQn",
+                  "name": "s300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$slate-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "u3ImX",
+                  "name": "s400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$slate-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "OuJfK",
+                  "name": "s500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$slate-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ibe30",
+                  "name": "s600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$slate-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Q8Dl3",
+                  "name": "s700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$slate-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "9ZCnX",
+                  "name": "s800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$slate-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "OyLnv",
+                  "name": "s900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$slate-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "mTHTP",
+                  "name": "s950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$slate-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "kPx4U",
+              "name": "slateOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.984 0.003 248) → 100(0.968 0.007 248) → 200(0.929 0.013 256) → 300(0.869 0.022 253) → 400(0.704 0.04 257) → 500(0.554 0.046 257) → 600(0.446 0.043 257) → 700(0.372 0.044 257) → 800(0.279 0.041 260) → 900(0.208 0.042 266) → 950(0.129 0.042 265)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "iNT2s",
+          "name": "Gray",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "kAcic",
+              "name": "grayLabel",
+              "fill": "$gray-700",
+              "content": "Gray",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "bcQR0",
+              "name": "graySw",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "VFzFn",
+                  "name": "g50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$gray-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Grlw2",
+                  "name": "g100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$gray-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "4t2Hi",
+                  "name": "g200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$gray-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Xoa5I",
+                  "name": "g300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$gray-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "zGhi3",
+                  "name": "g400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$gray-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "L7sdA",
+                  "name": "g500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$gray-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "kAU5l",
+                  "name": "g600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$gray-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "KgIWK",
+                  "name": "g700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$gray-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "lW1fx",
+                  "name": "g800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$gray-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "HhLHJ",
+                  "name": "g900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$gray-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "S6ahz",
+                  "name": "g950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$gray-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "C9kut",
+              "name": "grayOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.985 0.002 248) → 100(0.967 0.003 265) → 200(0.928 0.006 265) → 300(0.872 0.01 258) → 400(0.707 0.022 261) → 500(0.551 0.027 264) → 600(0.446 0.03 257) → 700(0.373 0.034 260) → 800(0.278 0.033 257) → 900(0.21 0.034 265) → 950(0.13 0.028 262)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "AoUWz",
+          "name": "Red",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "tU2w5",
+              "name": "redLabel",
+              "fill": "$red-700",
+              "content": "Red",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "2S4KD",
+              "name": "redSw",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "9SJvR",
+                  "name": "r50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$red-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "zy9uf",
+                  "name": "r100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$red-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "lBlS3",
+                  "name": "r200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$red-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "VuIuH",
+                  "name": "r300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$red-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Ph1xX",
+                  "name": "r400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$red-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "LwROx",
+                  "name": "r500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$red-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ZRkbG",
+                  "name": "r600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$red-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "pKNFm",
+                  "name": "r700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$red-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "VcmEw",
+                  "name": "r800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$red-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "4FzMH",
+                  "name": "r900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$red-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "QfIE9",
+                  "name": "r950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$red-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "imd8R",
+              "name": "redOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.971 0.013 17) → 100(0.936 0.032 18) → 200(0.885 0.062 18) → 300(0.808 0.114 20) → 400(0.704 0.191 22) → 500(0.637 0.237 25) → 600(0.577 0.245 27) → 700(0.505 0.213 28) → 800(0.444 0.177 27) → 900(0.396 0.141 26) → 950(0.258 0.092 26)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "LkhJP",
+          "name": "Orange",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "IuV0Q",
+              "name": "orangeLabel",
+              "fill": "$orange-700",
+              "content": "Orange",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "e66TV",
+              "name": "orangeSw",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "IiRpZ",
+                  "name": "o50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$orange-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "l7j7I",
+                  "name": "o100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$orange-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Ez91i",
+                  "name": "o200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$orange-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "jzOey",
+                  "name": "o300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$orange-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "mdeT1",
+                  "name": "o400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$orange-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "6tBWN",
+                  "name": "o500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$orange-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "4yrNJ",
+                  "name": "o600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$orange-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "WaqlD",
+                  "name": "o700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$orange-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "sT1R4",
+                  "name": "o800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$orange-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "sqGFw",
+                  "name": "o900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$orange-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "GtZhf",
+                  "name": "o950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$orange-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "E2FPn",
+              "name": "orangeOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.98 0.016 74) → 100(0.954 0.038 75) → 200(0.901 0.076 71) → 300(0.837 0.128 66) → 400(0.75 0.183 56) → 500(0.705 0.213 48) → 600(0.646 0.222 41) → 700(0.553 0.195 38) → 800(0.47 0.157 37) → 900(0.408 0.123 38) → 950(0.266 0.079 36)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "2BXDn",
+          "name": "Yellow",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "e3Rp7",
+              "name": "yellowLabel",
+              "fill": "$yellow-700",
+              "content": "Yellow",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "GNZGf",
+              "name": "yellowSw",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "RhJlZ",
+                  "name": "y50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$yellow-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "fKksQ",
+                  "name": "y100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$yellow-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "r7v5j",
+                  "name": "y200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$yellow-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Z1CrC",
+                  "name": "y300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$yellow-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "83f7J",
+                  "name": "y400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$yellow-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "en1TN",
+                  "name": "y500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$yellow-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "hp8zC",
+                  "name": "y600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$yellow-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "3PySv",
+                  "name": "y700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$yellow-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "3gogg",
+                  "name": "y800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$yellow-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "8d7Bd",
+                  "name": "y900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$yellow-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "xoFgL",
+                  "name": "y950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$yellow-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "NU1pI",
+              "name": "yellowOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.987 0.026 102) → 100(0.973 0.071 103) → 200(0.945 0.129 102) → 300(0.905 0.182 98) → 400(0.852 0.199 92) → 500(0.795 0.184 86) → 600(0.681 0.162 76) → 700(0.554 0.135 66) → 800(0.476 0.114 62) → 900(0.421 0.095 58) → 950(0.286 0.066 54)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "kDmHq",
+          "name": "Green",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "qfBXv",
+              "name": "greenLabel",
+              "fill": "$green-700",
+              "content": "Green",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "3Ncd4",
+              "name": "greenSw",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "T7yel",
+                  "name": "gn50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$green-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "i163Y",
+                  "name": "gn100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$green-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "7tFQw",
+                  "name": "gn200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$green-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "2BwK4",
+                  "name": "gn300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$green-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "srFdN",
+                  "name": "gn400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$green-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "X196Q",
+                  "name": "gn500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$green-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "aThG2",
+                  "name": "gn600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$green-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "UTmEK",
+                  "name": "gn700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$green-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "8zIOE",
+                  "name": "gn800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$green-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "uzWlb",
+                  "name": "gn900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$green-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "U8JmR",
+                  "name": "gn950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$green-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "jdRLu",
+              "name": "greenOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.982 0.018 156) → 100(0.962 0.044 157) → 200(0.925 0.084 156) → 300(0.871 0.15 154) → 400(0.792 0.209 152) → 500(0.723 0.219 150) → 600(0.627 0.194 149) → 700(0.527 0.154 150) → 800(0.448 0.119 151) → 900(0.393 0.095 153) → 950(0.266 0.065 153)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "WD6ZP",
+          "name": "Blue",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "3BP3E",
+              "name": "blueLabel",
+              "fill": "$blue-700",
+              "content": "Blue",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "EDH0T",
+              "name": "blueSw",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "XLYsu",
+                  "name": "b50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$blue-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "1rziP",
+                  "name": "b100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$blue-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ODXcC",
+                  "name": "b200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$blue-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "yttUY",
+                  "name": "b300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$blue-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "NTPOt",
+                  "name": "b400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$blue-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ngrq2",
+                  "name": "b500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$blue-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "0BUht",
+                  "name": "b600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$blue-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "bS0ak",
+                  "name": "b700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$blue-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Rchus",
+                  "name": "b800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$blue-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "QjKln",
+                  "name": "b900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$blue-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "VO28u",
+                  "name": "b950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$blue-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "SlIoC",
+              "name": "blueOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.97 0.014 255) → 100(0.932 0.032 256) → 200(0.882 0.059 254) → 300(0.809 0.105 252) → 400(0.707 0.165 255) → 500(0.623 0.214 260) → 600(0.546 0.245 263) → 700(0.488 0.243 264) → 800(0.424 0.199 266) → 900(0.379 0.146 266) → 950(0.282 0.091 268)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "QwgWJ",
+          "name": "Indigo",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "SNdWC",
+              "name": "indigoLabel",
+              "fill": "$indigo-700",
+              "content": "Indigo",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "oJgtp",
+              "name": "indigoSw",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "jYH5Y",
+                  "name": "i50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$indigo-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "l0Ty7",
+                  "name": "i100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$indigo-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "NB6oi",
+                  "name": "i200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$indigo-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "6eysY",
+                  "name": "i300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$indigo-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ZTbR1",
+                  "name": "i400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$indigo-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "hVA7m",
+                  "name": "i500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$indigo-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "NcEq0",
+                  "name": "i600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$indigo-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "0VB2Y",
+                  "name": "i700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$indigo-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "jrfNX",
+                  "name": "i800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$indigo-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Le8R6",
+                  "name": "i900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$indigo-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "wjzOQ",
+                  "name": "i950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$indigo-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "6ImSp",
+              "name": "indigoOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.962 0.018 272) → 100(0.93 0.034 273) → 200(0.87 0.065 274) → 300(0.785 0.115 275) → 400(0.673 0.182 277) → 500(0.585 0.233 277) → 600(0.511 0.262 277) → 700(0.457 0.24 277) → 800(0.398 0.195 277) → 900(0.359 0.144 279) → 950(0.257 0.09 281)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "5wnIW",
+          "name": "Purple",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "H8yD0",
+              "name": "purpleLabel",
+              "fill": "$purple-700",
+              "content": "Purple",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "Y5gQM",
+              "name": "purpleSw",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "qBV49",
+                  "name": "p50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$purple-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "XJrLN",
+                  "name": "p100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$purple-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "TM3Zo",
+                  "name": "p200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$purple-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "0J7ZK",
+                  "name": "p300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$purple-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "MJu7U",
+                  "name": "p400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$purple-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "zZt7t",
+                  "name": "p500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$purple-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "X14Lz",
+                  "name": "p600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$purple-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "BZQ2a",
+                  "name": "p700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$purple-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "sh8Cr",
+                  "name": "p800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$purple-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "3cRYK",
+                  "name": "p900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$purple-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "SOvSW",
+                  "name": "p950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$purple-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "FZB71",
+              "name": "purpleOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.977 0.014 308) → 100(0.946 0.033 307) → 200(0.902 0.063 307) → 300(0.827 0.119 306) → 400(0.714 0.203 306) → 500(0.627 0.265 304) → 600(0.558 0.288 302) → 700(0.496 0.265 302) → 800(0.438 0.218 304) → 900(0.381 0.176 305) → 950(0.291 0.149 303)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "aYGE2",
+          "name": "Pink",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "MbWwd",
+              "name": "pinkLabel",
+              "content": "Pink",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "XlAj7",
+              "name": "pinkSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "bbsy1",
+                  "name": "pink50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$pink-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "hfHrC",
+                  "name": "pink100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$pink-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "SMZtg",
+                  "name": "pink200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$pink-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "wzS1H",
+                  "name": "pink300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$pink-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ewMTy",
+                  "name": "pink400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$pink-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "1AO4w",
+                  "name": "pink500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$pink-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "IX0gx",
+                  "name": "pink600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$pink-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "kZUrI",
+                  "name": "pink700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$pink-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "uCBqW",
+                  "name": "pink800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$pink-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "hZ81a",
+                  "name": "pink900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$pink-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Hvhgh",
+                  "name": "pink950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$pink-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "yL0Vq",
+              "name": "pinkOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.971 0.014 343) → 100(0.948 0.028 342) → 200(0.899 0.061 343) → 300(0.823 0.12 346) → 400(0.718 0.202 350) → 500(0.656 0.241 354) → 600(0.592 0.249 1) → 700(0.525 0.223 4) → 800(0.459 0.187 4) → 900(0.408 0.153 2) → 950(0.284 0.109 4)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "melLG",
+          "name": "Rose",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "5sxZi",
+              "name": "roseLabel",
+              "fill": "#374151",
+              "content": "Rose",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "pLd4g",
+              "name": "roseSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "61BwN",
+                  "name": "rose50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$rose-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "InbpQ",
+                  "name": "rose100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$rose-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "59bbt",
+                  "name": "rose200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$rose-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "NiYgF",
+                  "name": "rose300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$rose-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "of7R4",
+                  "name": "rose400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$rose-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "nnc15",
+                  "name": "rose500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$rose-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "DuDdK",
+                  "name": "rose600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$rose-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Q9aIg",
+                  "name": "rose700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$rose-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "95QOF",
+                  "name": "rose800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$rose-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "qTE1B",
+                  "name": "rose900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$rose-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "o7Lqo",
+                  "name": "rose950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$rose-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "ib50d",
+              "name": "roseOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.969 0.015 12) → 100(0.941 0.03 13) → 200(0.892 0.058 10) → 300(0.81 0.117 12) → 400(0.712 0.194 13) → 500(0.645 0.246 16) → 600(0.586 0.253 18) → 700(0.514 0.222 17) → 800(0.455 0.188 14) → 900(0.41 0.159 10) → 950(0.271 0.105 12)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "De6fX",
+          "name": "Emerald",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "SLtGs",
+              "name": "emeraldLabel",
+              "fill": "#374151",
+              "content": "Emerald",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "VdHdS",
+              "name": "emeraldSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "qGiSE",
+                  "name": "emerald50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$emerald-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "kgXW0",
+                  "name": "emerald100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$emerald-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "IiZsb",
+                  "name": "emerald200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$emerald-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ONOot",
+                  "name": "emerald300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$emerald-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "p4yAX",
+                  "name": "emerald400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$emerald-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "JuwCg",
+                  "name": "emerald500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$emerald-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "MJZbz",
+                  "name": "emerald600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$emerald-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "av4bc",
+                  "name": "emerald700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$emerald-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "14niP",
+                  "name": "emerald800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$emerald-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ZDaHi",
+                  "name": "emerald900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$emerald-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "fPaxq",
+                  "name": "emerald950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$emerald-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "fqOal",
+              "name": "emeraldOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.979 0.021 166) → 100(0.95 0.052 163) → 200(0.905 0.093 164) → 300(0.845 0.143 165) → 400(0.765 0.177 163) → 500(0.696 0.17 162) → 600(0.596 0.145 163) → 700(0.508 0.118 166) → 800(0.432 0.095 167) → 900(0.378 0.077 169) → 950(0.262 0.051 173)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "iwh6V",
+          "name": "Teal",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "dt7CW",
+              "name": "tealLabel",
+              "fill": "#374151",
+              "content": "Teal",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "8RJGQ",
+              "name": "tealSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "6PvME",
+                  "name": "teal50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$teal-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "B3iCK",
+                  "name": "teal100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$teal-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "jGWMC",
+                  "name": "teal200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$teal-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "hYoUX",
+                  "name": "teal300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$teal-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "P0J83",
+                  "name": "teal400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$teal-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "cIn1k",
+                  "name": "teal500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$teal-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "FRIMf",
+                  "name": "teal600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$teal-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "k4Sb9",
+                  "name": "teal700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$teal-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "i98GN",
+                  "name": "teal800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$teal-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "aFU6R",
+                  "name": "teal900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$teal-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "YBi60",
+                  "name": "teal950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$teal-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "uHKsT",
+              "name": "tealOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.984 0.014 181) → 100(0.953 0.051 181) → 200(0.91 0.096 180) → 300(0.855 0.138 181) → 400(0.777 0.152 182) → 500(0.704 0.14 183) → 600(0.6 0.118 185) → 700(0.511 0.096 186) → 800(0.437 0.078 188) → 900(0.386 0.063 188) → 950(0.277 0.046 193)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "hKXuG",
+          "name": "Cyan",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "Sj1sA",
+              "name": "cyanLabel",
+              "fill": "#374151",
+              "content": "Cyan",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "dkAuR",
+              "name": "cyanSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ykJfb",
+                  "name": "cyan50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$cyan-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "lI3Mq",
+                  "name": "cyan100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$cyan-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Ejot2",
+                  "name": "cyan200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$cyan-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "yy8Xd",
+                  "name": "cyan300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$cyan-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "kmqiK",
+                  "name": "cyan400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$cyan-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "w1AwH",
+                  "name": "cyan500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$cyan-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "2bztm",
+                  "name": "cyan600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$cyan-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "4R0s1",
+                  "name": "cyan700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$cyan-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "arFiy",
+                  "name": "cyan800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$cyan-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "lJZ7O",
+                  "name": "cyan900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$cyan-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "AznYj",
+                  "name": "cyan950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$cyan-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "m9TgF",
+              "name": "cyanOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.984 0.019 201) → 100(0.956 0.045 203) → 200(0.917 0.08 205) → 300(0.865 0.127 207) → 400(0.789 0.154 212) → 500(0.715 0.143 215) → 600(0.609 0.126 222) → 700(0.52 0.105 223) → 800(0.45 0.085 224) → 900(0.398 0.07 227) → 950(0.302 0.056 230)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ROvZO",
+          "name": "Sky",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "ytvto",
+              "name": "skyLabel",
+              "fill": "#374151",
+              "content": "Sky",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "jiT77",
+              "name": "skySwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "r3TV8",
+                  "name": "sky50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$sky-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "pVsbK",
+                  "name": "sky100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$sky-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "DMGMA",
+                  "name": "sky200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$sky-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "h9NMm",
+                  "name": "sky300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$sky-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ysrOX",
+                  "name": "sky400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$sky-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "nY9ox",
+                  "name": "sky500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$sky-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "sGFG2",
+                  "name": "sky600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$sky-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "BZNl7",
+                  "name": "sky700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$sky-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "UItSM",
+                  "name": "sky800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$sky-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "XqvyQ",
+                  "name": "sky900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$sky-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "AnB7L",
+                  "name": "sky950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$sky-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "4FWAn",
+              "name": "skyOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.977 0.013 237) → 100(0.951 0.026 237) → 200(0.901 0.058 231) → 300(0.828 0.111 230) → 400(0.746 0.16 233) → 500(0.685 0.169 237) → 600(0.588 0.158 242) → 700(0.5 0.134 243) → 800(0.443 0.11 241) → 900(0.391 0.09 241) → 950(0.293 0.066 243)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "0O9RE",
+          "name": "Violet",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "6YVaG",
+              "name": "violetLabel",
+              "fill": "#374151",
+              "content": "Violet",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "L9YaC",
+              "name": "violetSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Nyqs4",
+                  "name": "violet50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$violet-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "fZA5x",
+                  "name": "violet100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$violet-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Rsrs5",
+                  "name": "violet200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$violet-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "IHGXZ",
+                  "name": "violet300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$violet-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "qmRZK",
+                  "name": "violet400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$violet-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "CMXHd",
+                  "name": "violet500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$violet-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "P9Z0G",
+                  "name": "violet600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$violet-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "3I4L9",
+                  "name": "violet700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$violet-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "CSQq4",
+                  "name": "violet800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$violet-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ldk8X",
+                  "name": "violet900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$violet-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "2w1ae",
+                  "name": "violet950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$violet-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "D6OM5",
+              "name": "violetOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.969 0.016 294) → 100(0.943 0.029 295) → 200(0.894 0.057 293) → 300(0.811 0.111 294) → 400(0.702 0.183 294) → 500(0.606 0.25 293) → 600(0.541 0.281 293) → 700(0.491 0.27 293) → 800(0.432 0.232 293) → 900(0.38 0.189 294) → 950(0.283 0.141 291)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "m1Gvg",
+          "name": "Fuchsia",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "EmtAv",
+              "name": "fuchsiaLabel",
+              "fill": "#374151",
+              "content": "Fuchsia",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "jd83j",
+              "name": "fuchsiaSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NPoyl",
+                  "name": "fuchsia50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$fuchsia-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "rbjO7",
+                  "name": "fuchsia100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$fuchsia-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "eUGdZ",
+                  "name": "fuchsia200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$fuchsia-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "gTJfl",
+                  "name": "fuchsia300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$fuchsia-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ZZYNs",
+                  "name": "fuchsia400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$fuchsia-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "wmuyJ",
+                  "name": "fuchsia500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$fuchsia-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "39tx7",
+                  "name": "fuchsia600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$fuchsia-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "5R6fT",
+                  "name": "fuchsia700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$fuchsia-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "8vBEb",
+                  "name": "fuchsia800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$fuchsia-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "5uky8",
+                  "name": "fuchsia900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$fuchsia-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ypU00",
+                  "name": "fuchsia950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$fuchsia-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "Jmg3Q",
+              "name": "fuchsiaOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.977 0.017 320) → 100(0.952 0.037 319) → 200(0.903 0.076 320) → 300(0.833 0.145 321) → 400(0.74 0.238 322) → 500(0.667 0.295 322) → 600(0.591 0.293 323) → 700(0.518 0.253 324) → 800(0.452 0.211 325) → 900(0.401 0.17 326) → 950(0.293 0.136 326)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "FYKDZ",
+          "name": "Amber",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "LGabB",
+              "name": "amberLabel",
+              "fill": "#374151",
+              "content": "Amber",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "ssrX5",
+              "name": "amberSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "9DvGD",
+                  "name": "amber50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$amber-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ci4xK",
+                  "name": "amber100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$amber-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "1D0AT",
+                  "name": "amber200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$amber-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "WWfKN",
+                  "name": "amber300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$amber-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "qatRL",
+                  "name": "amber400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$amber-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Ab0LB",
+                  "name": "amber500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$amber-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "hSQnE",
+                  "name": "amber600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$amber-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "YUOWe",
+                  "name": "amber700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$amber-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Tjm3J",
+                  "name": "amber800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$amber-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "w7wzy",
+                  "name": "amber900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$amber-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "cihn9",
+                  "name": "amber950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$amber-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "1CN1T",
+              "name": "amberOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.987 0.022 95) → 100(0.962 0.059 96) → 200(0.924 0.12 96) → 300(0.879 0.169 92) → 400(0.828 0.189 84) → 500(0.769 0.188 70) → 600(0.666 0.179 58) → 700(0.555 0.163 49) → 800(0.473 0.137 46) → 900(0.414 0.112 46) → 950(0.279 0.077 46)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "2Br8z",
+          "name": "Lime",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "5Jbfj",
+              "name": "limeLabel",
+              "fill": "#374151",
+              "content": "Lime",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "x3w2D",
+              "name": "limeSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "kr5PS",
+                  "name": "lime50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$lime-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "APbsJ",
+                  "name": "lime100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$lime-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "BaLIj",
+                  "name": "lime200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$lime-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "T3m4e",
+                  "name": "lime300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$lime-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "m1dGd",
+                  "name": "lime400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$lime-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "rqBY8",
+                  "name": "lime500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$lime-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "mPR94",
+                  "name": "lime600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$lime-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "7VjFp",
+                  "name": "lime700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$lime-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "f3teH",
+                  "name": "lime800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$lime-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "yDqzY",
+                  "name": "lime900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$lime-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "TSIG8",
+                  "name": "lime950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$lime-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "kLP2K",
+              "name": "limeOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.986 0.031 121) → 100(0.967 0.067 122) → 200(0.938 0.127 124) → 300(0.897 0.196 127) → 400(0.841 0.238 129) → 500(0.768 0.233 131) → 600(0.648 0.2 132) → 700(0.532 0.157 132) → 800(0.453 0.124 131) → 900(0.405 0.101 131) → 950(0.274 0.072 132)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "LAxHY",
+          "name": "Zinc",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "TZnFp",
+              "name": "zincLabel",
+              "fill": "#374151",
+              "content": "Zinc",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "682J2",
+              "name": "zincSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dOGl3",
+                  "name": "zinc50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$zinc-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "pmQhs",
+                  "name": "zinc100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$zinc-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "42PJf",
+                  "name": "zinc200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$zinc-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "noSNG",
+                  "name": "zinc300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$zinc-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "sMAeS",
+                  "name": "zinc400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$zinc-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "2V1se",
+                  "name": "zinc500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$zinc-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "d8KDa",
+                  "name": "zinc600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$zinc-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "tpXyd",
+                  "name": "zinc700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$zinc-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "vMhbF",
+                  "name": "zinc800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$zinc-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "vblRP",
+                  "name": "zinc900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$zinc-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "6lpXr",
+                  "name": "zinc950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$zinc-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "x3gjM",
+              "name": "zincOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.985 0 0) → 100(0.967 0.001 286) → 200(0.92 0.004 286) → 300(0.871 0.006 286) → 400(0.705 0.015 286) → 500(0.552 0.016 286) → 600(0.442 0.017 286) → 700(0.37 0.013 286) → 800(0.274 0.006 286) → 900(0.21 0.006 269) → 950(0.141 0.005 286)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "fKXeX",
+          "name": "Neutral",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "4EDWd",
+              "name": "neutralLabel",
+              "fill": "#374151",
+              "content": "Neutral",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "bFM6C",
+              "name": "neutralSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fZEF4",
+                  "name": "neutral50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$neutral-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "4MbeL",
+                  "name": "neutral100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$neutral-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "BOSED",
+                  "name": "neutral200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$neutral-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "1OzrL",
+                  "name": "neutral300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$neutral-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "FROeL",
+                  "name": "neutral400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$neutral-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "6s6XN",
+                  "name": "neutral500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$neutral-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "vRczk",
+                  "name": "neutral600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$neutral-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "3nDEa",
+                  "name": "neutral700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$neutral-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "p4cWW",
+                  "name": "neutral800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$neutral-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "IiLOk",
+                  "name": "neutral900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$neutral-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "ZmNaI",
+                  "name": "neutral950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$neutral-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "0OSlq",
+              "name": "neutralOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.985 0 0) → 100(0.97 0 0) → 200(0.922 0 0) → 300(0.87 0 0) → 400(0.708 0.001 49) → 500(0.556 0.002 107) → 600(0.439 0.003 68) → 700(0.371 0.003 56) → 800(0.269 0.001 34) → 900(0.205 0.001 34) → 950(0.145 0.001 34)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "QCPo3",
+          "name": "Stone",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "pMTlt",
+              "name": "stoneLabel",
+              "fill": "#374151",
+              "content": "Stone",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "EhP4N",
+              "name": "stoneSwatches",
+              "width": "fill_container",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "I6sCw",
+                  "name": "stone50",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$stone-50",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "WOGbQ",
+                  "name": "stone100",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$stone-100",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "Bl1f1",
+                  "name": "stone200",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$stone-200",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "mrXNV",
+                  "name": "stone300",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$stone-300",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "sOJfX",
+                  "name": "stone400",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$stone-400",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "rGVEf",
+                  "name": "stone500",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$stone-500",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "L7huW",
+                  "name": "stone600",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$stone-600",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "2JY7W",
+                  "name": "stone700",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$stone-700",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "is7DV",
+                  "name": "stone800",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$stone-800",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "FEXNM",
+                  "name": "stone900",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$stone-900",
+                  "cornerRadius": 4
+                },
+                {
+                  "type": "frame",
+                  "id": "zsLpc",
+                  "name": "stone950",
+                  "width": 80,
+                  "height": 48,
+                  "fill": "$stone-950",
+                  "cornerRadius": 4
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "t7aqz",
+              "name": "stoneOklch",
+              "fill": "#9ca3af",
+              "content": "OKLCH: 50(0.985 0.001 107) → 100(0.97 0.001 107) → 200(0.923 0.003 74) → 300(0.869 0.005 57) → 400(0.709 0.01 56) → 500(0.553 0.013 58) → 600(0.444 0.011 73) → 700(0.374 0.01 68) → 800(0.268 0.007 34) → 900(0.216 0.006 57) → 950(0.147 0.004 50)",
+              "fontFamily": "Inter",
+              "fontSize": 9,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "oS6qb",
+      "x": 1700,
+      "y": 1200,
+      "name": "Design Tokens - Spacing",
+      "width": 1000,
+      "height": 1400,
+      "fill": "#ffffff",
+      "layout": "vertical",
+      "gap": 24,
+      "padding": 40,
+      "children": [
+        {
+          "type": "text",
+          "id": "OTRYn",
+          "name": "spacingTitle",
+          "fill": "#1a1a1a",
+          "content": "Tailwind CSS Spacing Scale",
+          "fontFamily": "Inter",
+          "fontSize": 32,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "U1eK1",
+          "name": "spacingSubtitle",
+          "fill": "#6b7280",
+          "content": "0 to 96 (384px) spacing values",
+          "fontFamily": "Inter",
+          "fontSize": 16,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "HZwTC",
+          "name": "Spacing Items",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 12,
+          "children": [
+            {
+              "type": "frame",
+              "id": "WmvMB",
+              "name": "sp0",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "vhzbX",
+                  "name": "sp0Label",
+                  "fill": "#374151",
+                  "content": "0 (0px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "hnAWP",
+                  "name": "sp0Bar",
+                  "width": 1,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eUsfq",
+              "name": "sp1",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "7AwS9",
+                  "name": "sp1Label",
+                  "fill": "#374151",
+                  "content": "1 (4px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "mhn9m",
+                  "name": "sp1Bar",
+                  "width": 4,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "fnlLJ",
+              "name": "sp2",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "XWLYd",
+                  "name": "sp2Label",
+                  "fill": "#374151",
+                  "content": "2 (8px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "ZqTqZ",
+                  "name": "sp2Bar",
+                  "width": 8,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "4sKpX",
+              "name": "sp3",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "PLtI4",
+                  "name": "sp3Label",
+                  "fill": "#374151",
+                  "content": "3 (12px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "KLAx4",
+                  "name": "sp3Bar",
+                  "width": 12,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "hgKTz",
+              "name": "sp4",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "D6MZr",
+                  "name": "sp4Label",
+                  "fill": "#374151",
+                  "content": "4 (16px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "1uDsi",
+                  "name": "sp4Bar",
+                  "width": 16,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "QVkpc",
+              "name": "sp5",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "soXIS",
+                  "name": "sp5Label",
+                  "fill": "#374151",
+                  "content": "5 (20px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "s8kAQ",
+                  "name": "sp5Bar",
+                  "width": 20,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "SgB3c",
+              "name": "sp6",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "pzuUr",
+                  "name": "sp6Label",
+                  "fill": "#374151",
+                  "content": "6 (24px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "SoCtJ",
+                  "name": "sp6Bar",
+                  "width": 24,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Ww2PB",
+              "name": "sp8",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "9SxQk",
+                  "name": "sp8Label",
+                  "fill": "#374151",
+                  "content": "8 (32px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "x2HTd",
+                  "name": "sp8Bar",
+                  "width": 32,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "juraL",
+              "name": "sp10",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "MqLiu",
+                  "name": "sp10Label",
+                  "fill": "#374151",
+                  "content": "10 (40px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "24zgM",
+                  "name": "sp10Bar",
+                  "width": 40,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "P0133",
+              "name": "sp12",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "2tW3a",
+                  "name": "sp12Label",
+                  "fill": "#374151",
+                  "content": "12 (48px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "1VjCi",
+                  "name": "sp12Bar",
+                  "width": 48,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Qnhix",
+              "name": "sp16",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "WpUF1",
+                  "name": "sp16Label",
+                  "fill": "#374151",
+                  "content": "16 (64px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "yeXsp",
+                  "name": "sp16Bar",
+                  "width": 64,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "BM4Ey",
+              "name": "sp20",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "JmP3i",
+                  "name": "sp20Label",
+                  "fill": "#374151",
+                  "content": "20 (80px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "nBGpH",
+                  "name": "sp20Bar",
+                  "width": 80,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "olPxs",
+              "name": "sp24",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "b4qZ0",
+                  "name": "sp24Label",
+                  "fill": "#374151",
+                  "content": "24 (96px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "Ud0hZ",
+                  "name": "sp24Bar",
+                  "width": 96,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "oYn9z",
+              "name": "sp32",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "p2kZ8",
+                  "name": "sp32Label",
+                  "fill": "#374151",
+                  "content": "32 (128px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "keQyS",
+                  "name": "sp32Bar",
+                  "width": 128,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "nPSFY",
+              "name": "sp40",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "HTulf",
+                  "name": "sp40Label",
+                  "fill": "#374151",
+                  "content": "40 (160px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "UJVGm",
+                  "name": "sp40Bar",
+                  "width": 160,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "P84Gj",
+              "name": "sp48",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Jo48P",
+                  "name": "sp48Label",
+                  "fill": "#374151",
+                  "content": "48 (192px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "vtuwd",
+                  "name": "sp48Bar",
+                  "width": 192,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "HM4uB",
+              "name": "sp56",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dWpP8",
+                  "name": "sp56Label",
+                  "fill": "#374151",
+                  "content": "56 (224px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "5tJzY",
+                  "name": "sp56Bar",
+                  "width": 224,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "hdXun",
+              "name": "sp64",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "5Ma9G",
+                  "name": "sp64Label",
+                  "fill": "#374151",
+                  "content": "64 (256px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "nKngA",
+                  "name": "sp64Bar",
+                  "width": 256,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "W8nSc",
+              "name": "sp72",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "NvngF",
+                  "name": "sp72Label",
+                  "fill": "#374151",
+                  "content": "72 (288px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "IxrvO",
+                  "name": "sp72Bar",
+                  "width": 288,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "iLUaX",
+              "name": "sp80",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "JAFnU",
+                  "name": "sp80Label",
+                  "fill": "#374151",
+                  "content": "80 (320px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "a9wbw",
+                  "name": "sp80Bar",
+                  "width": 320,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "l3WzJ",
+              "name": "sp96",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "hlLmC",
+                  "name": "sp96Label",
+                  "fill": "#374151",
+                  "content": "96 (384px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "pOctb",
+                  "name": "sp96Bar",
+                  "width": 384,
+                  "height": 24,
+                  "fill": "#3b82f6",
+                  "cornerRadius": 2
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "zPpIB",
+      "x": 2800,
+      "y": 1200,
+      "name": "Design Tokens - Typography",
+      "width": 1000,
+      "height": 1200,
+      "fill": "#ffffff",
+      "layout": "vertical",
+      "gap": 32,
+      "padding": 40,
+      "children": [
+        {
+          "type": "text",
+          "id": "CxfsY",
+          "name": "typoTitle",
+          "fill": "#1a1a1a",
+          "content": "Tailwind CSS Font Sizes",
+          "fontFamily": "Inter",
+          "fontSize": 32,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "c3V8w",
+          "name": "typoSubtitle",
+          "fill": "#6b7280",
+          "content": "xs (12px) to 9xl (128px)",
+          "fontFamily": "Inter",
+          "fontSize": 16,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "g4sgD",
+          "name": "Typography Items",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "children": [
+            {
+              "type": "frame",
+              "id": "VigVG",
+              "name": "fsXs",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "6hoQd",
+                  "name": "fsXsLabel",
+                  "fill": "#6b7280",
+                  "content": "text-xs (12px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "7Qod5",
+                  "name": "fsXsText",
+                  "fill": "#1a1a1a",
+                  "content": "The quick brown fox jumps over the lazy dog",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "OfG1Y",
+              "name": "fsSm",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "3rpPO",
+                  "name": "fsSmLabel",
+                  "fill": "#6b7280",
+                  "content": "text-sm (14px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "Asrpb",
+                  "name": "fsSmText",
+                  "fill": "#1a1a1a",
+                  "content": "The quick brown fox jumps over the lazy dog",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "gzL69",
+              "name": "fsBase",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "2JLjG",
+                  "name": "fsBaseLabel",
+                  "fill": "#6b7280",
+                  "content": "text-base (16px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "uSp1A",
+                  "name": "fsBaseText",
+                  "fill": "#1a1a1a",
+                  "content": "The quick brown fox jumps over the lazy dog",
+                  "fontFamily": "Inter",
+                  "fontSize": 16,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sx3DF",
+              "name": "fsLg",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "f1ooG",
+                  "name": "fsLgLabel",
+                  "fill": "#6b7280",
+                  "content": "text-lg (18px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "c83H5",
+                  "name": "fsLgText",
+                  "fill": "#1a1a1a",
+                  "content": "The quick brown fox jumps over the lazy dog",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "vuoMO",
+              "name": "fsXl",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "xLxu3",
+                  "name": "fsXlLabel",
+                  "fill": "#6b7280",
+                  "content": "text-xl (20px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "rePx7",
+                  "name": "fsXlText",
+                  "fill": "#1a1a1a",
+                  "content": "The quick brown fox jumps over the lazy dog",
+                  "fontFamily": "Inter",
+                  "fontSize": 20,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "71U4P",
+              "name": "fs2xl",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "OVmWI",
+                  "name": "fs2xlLabel",
+                  "fill": "#6b7280",
+                  "content": "text-2xl (24px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "Q5STp",
+                  "name": "fs2xlText",
+                  "fill": "#1a1a1a",
+                  "content": "The quick brown fox jumps",
+                  "fontFamily": "Inter",
+                  "fontSize": 24,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "YDdzi",
+              "name": "fs3xl",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "JFBbf",
+                  "name": "fs3xlLabel",
+                  "fill": "#6b7280",
+                  "content": "text-3xl (30px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "aPU4d",
+                  "name": "fs3xlText",
+                  "fill": "#1a1a1a",
+                  "content": "The quick brown fox jumps",
+                  "fontFamily": "Inter",
+                  "fontSize": 30,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Nt3K5",
+              "name": "fs4xl",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "SvYck",
+                  "name": "fs4xlLabel",
+                  "fill": "#6b7280",
+                  "content": "text-4xl (36px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "2uUHV",
+                  "name": "fs4xlText",
+                  "fill": "#1a1a1a",
+                  "content": "The quick brown fox",
+                  "fontFamily": "Inter",
+                  "fontSize": 36,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "jxa5y",
+              "name": "fs5xl",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "eYlnB",
+                  "name": "fs5xlLabel",
+                  "fill": "#6b7280",
+                  "content": "text-5xl (48px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "Do78Y",
+                  "name": "fs5xlText",
+                  "fill": "#1a1a1a",
+                  "content": "The quick brown fox",
+                  "fontFamily": "Inter",
+                  "fontSize": 48,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cdYun",
+              "name": "fs6xl",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "7S9TT",
+                  "name": "fs6xlLabel",
+                  "fill": "#6b7280",
+                  "content": "text-6xl (60px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "lTEW5",
+                  "name": "fs6xlText",
+                  "fill": "#1a1a1a",
+                  "content": "Quick brown fox",
+                  "fontFamily": "Inter",
+                  "fontSize": 60,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "4s2Cc",
+              "name": "fs7xl",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "9QHMv",
+                  "name": "fs7xlLabel",
+                  "fill": "#6b7280",
+                  "content": "text-7xl (72px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "wn7u5",
+                  "name": "fs7xlText",
+                  "fill": "#1a1a1a",
+                  "content": "Quick fox",
+                  "fontFamily": "Inter",
+                  "fontSize": 72,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "c2e9b",
+              "name": "fs8xl",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "NRWqc",
+                  "name": "fs8xlLabel",
+                  "fill": "#6b7280",
+                  "content": "text-8xl (96px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "3fV7G",
+                  "name": "fs8xlText",
+                  "fill": "#1a1a1a",
+                  "content": "Quick",
+                  "fontFamily": "Inter",
+                  "fontSize": 96,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Bd89o",
+              "name": "fs9xl",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "TCXxY",
+                  "name": "fs9xlLabel",
+                  "fill": "#6b7280",
+                  "content": "text-9xl (128px)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "JA4pu",
+                  "name": "fs9xlText",
+                  "fill": "#1a1a1a",
+                  "content": "Fox",
+                  "fontFamily": "Inter",
+                  "fontSize": 128,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "byyU1",
+      "x": 3900,
+      "y": 1200,
+      "name": "Components Library",
+      "width": 1200,
+      "fill": "#ffffff",
+      "layout": "vertical",
+      "gap": 48,
+      "padding": 48,
+      "children": [
+        {
+          "type": "text",
+          "id": "wcUas",
+          "name": "pageTitle",
+          "fill": "#1a1a1a",
+          "content": "Components Library",
+          "fontFamily": "Inter",
+          "fontSize": 48,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "DwAcf",
+          "name": "pageSubtitle",
+          "fill": "#6b7280",
+          "content": "Reusable UI components for the portfolio",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "ZXoxR",
+          "name": "Buttons Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "children": [
+            {
+              "type": "text",
+              "id": "VZSeR",
+              "name": "buttonsTitle",
+              "fill": "#374151",
+              "content": "Buttons",
+              "fontFamily": "Inter",
+              "fontSize": 24,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "KhhqS",
+              "name": "buttonsDesc",
+              "fill": "#9ca3af",
+              "content": "Primary and secondary button variants",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "nJdIK",
+              "name": "Button Examples",
+              "gap": 24,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "Qz98e",
+                  "type": "ref",
+                  "ref": "qIlVR",
+                  "name": "btnPrimary"
+                },
+                {
+                  "id": "DfSiV",
+                  "type": "ref",
+                  "ref": "JJp9T",
+                  "name": "btnSecondary"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "lt38V",
+          "name": "Navigation Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "children": [
+            {
+              "type": "text",
+              "id": "rF9ae",
+              "name": "navTitle",
+              "fill": "#374151",
+              "content": "Navigation",
+              "fontFamily": "Inter",
+              "fontSize": 24,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "I8G4T",
+              "name": "navDesc",
+              "fill": "#9ca3af",
+              "content": "Logo and navigation link components",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "vCbtQ",
+              "name": "Navigation Examples",
+              "gap": 48,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "BTE9d",
+                  "type": "ref",
+                  "ref": "v08Ll",
+                  "name": "logoInstance"
+                },
+                {
+                  "id": "eAKJR",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "name": "navLink1",
+                  "content": "Works"
+                },
+                {
+                  "id": "hbWqW",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "name": "navLink2",
+                  "content": "About"
+                },
+                {
+                  "id": "kj0qd",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "name": "navLink3",
+                  "content": "Links"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "NSJ9o",
+          "name": "Component Definitions",
+          "width": "fill_container",
+          "fill": "#f9fafb",
+          "cornerRadius": 12,
+          "layout": "vertical",
+          "gap": 24,
+          "padding": 24,
+          "children": [
+            {
+              "type": "text",
+              "id": "rEZPO",
+              "name": "defsTitle",
+              "fill": "#374151",
+              "content": "Component Definitions (Masters)",
+              "fontFamily": "Inter",
+              "fontSize": 24,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "OilEQ",
+              "name": "defsDesc",
+              "fill": "#9ca3af",
+              "content": "Source components - instances above reference these",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "VO8CU",
+              "name": "Definitions Row",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "qIlVR",
+                  "name": "Component/Button/Primary",
+                  "reusable": true,
+                  "fill": "$text-primary",
+                  "cornerRadius": 9999,
+                  "padding": [
+                    16,
+                    40
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "0IKVR",
+                      "name": "Label",
+                      "fill": "$bg-surface",
+                      "content": "View Works",
+                      "fontFamily": "$font-body",
+                      "fontSize": 16,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JJp9T",
+                  "name": "Component/Button/Secondary",
+                  "reusable": true,
+                  "fill": "transparent",
+                  "cornerRadius": 9999,
+                  "stroke": {
+                    "thickness": 2,
+                    "fill": "$text-primary"
+                  },
+                  "padding": [
+                    16,
+                    40
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "MIU27",
+                      "name": "Label",
+                      "fill": "$text-primary",
+                      "content": "Links",
+                      "fontFamily": "$font-body",
+                      "fontSize": 16,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "FJk13",
+                  "name": "Component/NavLink",
+                  "reusable": true,
+                  "fill": "$text-primary",
+                  "content": "Link",
+                  "fontFamily": "$font-body",
+                  "fontSize": 16,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "v08Ll",
+                  "name": "Component/Logo",
+                  "reusable": true,
+                  "fill": "$text-primary",
+                  "content": "ta93abe",
+                  "fontFamily": "$font-display",
+                  "fontSize": 20,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "frame",
+                  "id": "ZaN91",
+                  "name": "Component/WorkCard",
+                  "reusable": true,
+                  "width": 380,
+                  "fill": "$bg-surface",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "$border-color"
+                  },
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "v9BuY",
+                      "name": "Cover Image",
+                      "width": "fill_container",
+                      "height": 200,
+                      "fill": "$slate-200"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "mXtts",
+                      "name": "Card Content",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 12,
+                      "padding": 16,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "pZN6e",
+                          "name": "cardTitle",
+                          "fill": "$text-primary",
+                          "content": "Project Title",
+                          "fontFamily": "Inter",
+                          "fontSize": 20,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ZbNcE",
+                          "name": "cardExcerpt",
+                          "fill": "$text-secondary",
+                          "content": "プロジェクトの説明文がここに入ります。",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Q4cIO",
+                          "name": "Tags",
+                          "gap": 8,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "p46H1",
+                              "name": "tag1",
+                              "fill": "$blue-100",
+                              "cornerRadius": 9999,
+                              "padding": [
+                                4,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "uG7vc",
+                                  "name": "tag1Text",
+                                  "fill": "$blue-700",
+                                  "content": "React",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "QKR5s",
+                              "name": "tag2",
+                              "fill": "$green-100",
+                              "cornerRadius": 9999,
+                              "padding": [
+                                4,
+                                12
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "hv8Hl",
+                                  "name": "tag2Text",
+                                  "fill": "$green-700",
+                                  "content": "TypeScript",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HaoZE",
+                  "name": "Component/BlogPostItem",
+                  "reusable": true,
+                  "width": 800,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "$border-color"
+                  },
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": [
+                    24,
+                    0
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "NAuAh",
+                      "name": "postDate",
+                      "fill": "$text-muted",
+                      "content": "2024年1月15日",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "u2FXW",
+                      "name": "postTitle",
+                      "fill": "$text-primary",
+                      "content": "ブログ記事のタイトル",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "1h9ql",
+                      "name": "postExcerpt",
+                      "fill": "$text-secondary",
+                      "content": "記事の概要テキストがここに入ります。読者の興味を引く内容を簡潔にまとめます。",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "5k2R3",
+                      "name": "Post Tags",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "AnY46",
+                          "name": "postTag1",
+                          "fill": "$slate-100",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            4,
+                            12
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "951hw",
+                              "name": "postTag1Text",
+                              "fill": "$slate-700",
+                              "content": "技術",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "AnbBZ",
+                  "name": "Component/SnsLinkItem",
+                  "reusable": true,
+                  "width": 400,
+                  "fill": "$bg-surface",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "$border-color"
+                  },
+                  "gap": 16,
+                  "padding": 16,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "gbq50",
+                      "name": "Icon",
+                      "width": 48,
+                      "height": 48,
+                      "fill": "$slate-200",
+                      "cornerRadius": 12,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XF505",
+                          "name": "snsIconText",
+                          "fill": "$slate-600",
+                          "content": "X",
+                          "fontFamily": "Inter",
+                          "fontSize": 20,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "pJzi3",
+                      "name": "Info",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qXADo",
+                          "name": "snsName",
+                          "fill": "$text-primary",
+                          "content": "Twitter / X",
+                          "fontFamily": "Inter",
+                          "fontSize": 18,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "m2Xh3",
+                          "name": "snsHandle",
+                          "fill": "$text-muted",
+                          "content": "@ta93abe",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BndNx",
+                  "name": "Component/ToolCard",
+                  "reusable": true,
+                  "width": 300,
+                  "fill": "$bg-surface",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "$border-color"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 16,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "CdHXJ",
+                      "name": "toolName",
+                      "fill": "$blue-600",
+                      "content": "Tool Name",
+                      "fontFamily": "SF Mono",
+                      "fontSize": 18,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "qoMv0",
+                      "name": "toolDesc",
+                      "fill": "$text-secondary",
+                      "content": "ツールの説明文がここに入ります",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "axro8",
+                      "name": "toolUrl",
+                      "fill": "$text-muted",
+                      "content": "https://example.com",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "VAPUD",
+      "x": 1540,
+      "y": 0,
+      "name": "Works Page",
+      "width": 1440,
+      "fill": "$bg-primary",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "AeSRe",
+          "name": "worksHeader",
+          "width": "fill_container",
+          "fill": "$bg-surface",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-color"
+          },
+          "padding": [
+            16,
+            48
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "id": "v3Mxu",
+              "type": "ref",
+              "ref": "v08Ll",
+              "name": "headerLogo"
+            },
+            {
+              "type": "frame",
+              "id": "pgWNX",
+              "name": "Nav Links",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "uDBQP",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Home",
+                  "name": "navHome"
+                },
+                {
+                  "id": "WjKcT",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Works",
+                  "name": "navWorks"
+                },
+                {
+                  "id": "ZEVK6",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Blog",
+                  "name": "navBlog"
+                },
+                {
+                  "id": "Td09W",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Links",
+                  "name": "navLinks"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "xJFRZ",
+          "name": "Works Main",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            48,
+            96
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "8I83I",
+              "name": "worksTitle",
+              "fill": "$text-primary",
+              "content": "Works",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "700"
+            },
+            {
+              "type": "frame",
+              "id": "lRpbP",
+              "name": "Works Grid",
+              "width": "fill_container",
+              "gap": 24,
+              "children": [
+                {
+                  "id": "TDPXN",
+                  "type": "ref",
+                  "ref": "ZaN91",
+                  "name": "card1",
+                  "descendants": {
+                    "pZN6e": {
+                      "content": "Portfolio Website"
+                    },
+                    "ZbNcE": {
+                      "content": "Astro + Tailwind CSS で構築した個人サイト"
+                    }
+                  }
+                },
+                {
+                  "id": "wSFZZ",
+                  "type": "ref",
+                  "ref": "ZaN91",
+                  "name": "card2",
+                  "descendants": {
+                    "pZN6e": {
+                      "content": "E-Commerce Platform"
+                    },
+                    "ZbNcE": {
+                      "content": "Next.js ベースのECサイト構築"
+                    }
+                  }
+                },
+                {
+                  "id": "0yzDl",
+                  "type": "ref",
+                  "ref": "ZaN91",
+                  "name": "card3",
+                  "descendants": {
+                    "pZN6e": {
+                      "content": "Design System"
+                    },
+                    "ZbNcE": {
+                      "content": "社内向けデザインシステムの設計・実装"
+                    }
+                  }
+                },
+                {
+                  "id": "wQdzV",
+                  "type": "ref",
+                  "ref": "ZaN91",
+                  "name": "card4",
+                  "descendants": {
+                    "pZN6e": {
+                      "content": "Mobile App"
+                    },
+                    "ZbNcE": {
+                      "content": "React Native クロスプラットフォームアプリ"
+                    }
+                  }
+                },
+                {
+                  "id": "eCkEM",
+                  "type": "ref",
+                  "ref": "ZaN91",
+                  "name": "card5",
+                  "descendants": {
+                    "pZN6e": {
+                      "content": "Analytics Dashboard"
+                    },
+                    "ZbNcE": {
+                      "content": "データ可視化ダッシュボードの開発"
+                    }
+                  }
+                },
+                {
+                  "id": "wURhH",
+                  "type": "ref",
+                  "ref": "ZaN91",
+                  "name": "card6",
+                  "descendants": {
+                    "pZN6e": {
+                      "content": "CLI Tool"
+                    },
+                    "ZbNcE": {
+                      "content": "Node.js 製の開発支援ツール"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ys9EZ",
+          "name": "worksFooter",
+          "width": "fill_container",
+          "fill": "$bg-gray",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-color"
+          },
+          "layout": "vertical",
+          "padding": 32,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "yKtLq",
+              "name": "footerText",
+              "fill": "$text-muted",
+              "content": "© 2024 ta93abe. All rights reserved.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "MThFO",
+      "x": 3080,
+      "y": 0,
+      "name": "Blog Page",
+      "width": 1440,
+      "fill": "$bg-primary",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "kVamc",
+          "name": "blogHeader",
+          "width": "fill_container",
+          "fill": "$bg-surface",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-color"
+          },
+          "padding": [
+            16,
+            48
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "id": "FMe3L",
+              "type": "ref",
+              "ref": "v08Ll",
+              "name": "headerLogo"
+            },
+            {
+              "type": "frame",
+              "id": "9AogQ",
+              "name": "Nav Links",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "iCYvn",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Home",
+                  "name": "navHome"
+                },
+                {
+                  "id": "kQtQu",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Works",
+                  "name": "navWorks"
+                },
+                {
+                  "id": "oqxSg",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Blog",
+                  "name": "navBlog"
+                },
+                {
+                  "id": "l4Guw",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Links",
+                  "name": "navLinks"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "iaGGJ",
+          "name": "Blog Main",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            48,
+            200
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "hJATb",
+              "name": "Title Row",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "j31ts",
+                  "name": "blogTitle",
+                  "fill": "$text-primary",
+                  "content": "Blog",
+                  "fontFamily": "Inter",
+                  "fontSize": 36,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "frame",
+                  "id": "Zkpfp",
+                  "name": "rssButton",
+                  "fill": "$orange-50",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    16
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "610ej",
+                      "name": "rssText",
+                      "fill": "$orange-600",
+                      "content": "RSS",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Ihk8L",
+              "name": "Blog List",
+              "width": "fill_container",
+              "layout": "vertical",
+              "children": [
+                {
+                  "id": "F7lUS",
+                  "type": "ref",
+                  "ref": "HaoZE",
+                  "name": "post1",
+                  "descendants": {
+                    "NAuAh": {
+                      "content": "2024年1月15日"
+                    },
+                    "u2FXW": {
+                      "content": "Astro 5.0 の新機能を試してみた"
+                    },
+                    "1h9ql": {
+                      "content": "Astro 5.0 がリリースされたので、新機能のContent Layerやサーバーアイランドを試してみました。"
+                    }
+                  }
+                },
+                {
+                  "id": "tWWRU",
+                  "type": "ref",
+                  "ref": "HaoZE",
+                  "name": "post2",
+                  "descendants": {
+                    "NAuAh": {
+                      "content": "2024年1月10日"
+                    },
+                    "u2FXW": {
+                      "content": "Tailwind CSS v4 への移行ガイド"
+                    },
+                    "1h9ql": {
+                      "content": "Tailwind CSS v4 の主な変更点と、既存プロジェクトからの移行方法をまとめました。"
+                    }
+                  }
+                },
+                {
+                  "id": "jzMHB",
+                  "type": "ref",
+                  "ref": "HaoZE",
+                  "name": "post3",
+                  "descendants": {
+                    "NAuAh": {
+                      "content": "2024年1月5日"
+                    },
+                    "u2FXW": {
+                      "content": "TypeScript 5.3 の satisfies 演算子活用術"
+                    },
+                    "1h9ql": {
+                      "content": "TypeScript 5.3 で追加された satisfies 演算子の実践的な使い方を解説します。"
+                    }
+                  }
+                },
+                {
+                  "id": "bRCkS",
+                  "type": "ref",
+                  "ref": "HaoZE",
+                  "name": "post4",
+                  "descendants": {
+                    "NAuAh": {
+                      "content": "2023年12月28日"
+                    },
+                    "u2FXW": {
+                      "content": "2023年の振り返りと2024年の目標"
+                    },
+                    "1h9ql": {
+                      "content": "2023年に取り組んだプロジェクトを振り返り、来年の目標を設定しました。"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "7eYV5",
+          "name": "blogFooter",
+          "width": "fill_container",
+          "fill": "$bg-gray",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-color"
+          },
+          "layout": "vertical",
+          "padding": 32,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "B4r96",
+              "name": "footerText",
+              "fill": "$text-muted",
+              "content": "© 2024 ta93abe. All rights reserved.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "TM9nN",
+      "x": 4620,
+      "y": 0,
+      "name": "Links Page",
+      "width": 1440,
+      "fill": "$bg-primary",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "ghiby",
+          "name": "linksHeader",
+          "width": "fill_container",
+          "fill": "$bg-surface",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-color"
+          },
+          "padding": [
+            16,
+            48
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "id": "QFsJ8",
+              "type": "ref",
+              "ref": "v08Ll",
+              "name": "headerLogo"
+            },
+            {
+              "type": "frame",
+              "id": "nLSfK",
+              "name": "Nav Links",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "TNeuo",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Home",
+                  "name": "navHome"
+                },
+                {
+                  "id": "QDfEz",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Works",
+                  "name": "navWorks"
+                },
+                {
+                  "id": "ZfnWP",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Blog",
+                  "name": "navBlog"
+                },
+                {
+                  "id": "IQ2Tf",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Links",
+                  "name": "navLinks"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Y3B6E",
+          "name": "Links Main",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            48,
+            200
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "bmMV0",
+              "name": "linksTitle",
+              "fill": "$text-primary",
+              "content": "Links",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "ZYxQn",
+              "name": "linksDesc",
+              "fill": "$text-secondary",
+              "content": "SNS・ソーシャルメディアのリンク一覧です。",
+              "fontFamily": "Inter",
+              "fontSize": 16,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "M3riF",
+              "name": "Links Grid",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "id": "iCtMU",
+                  "type": "ref",
+                  "ref": "AnbBZ",
+                  "name": "link1",
+                  "descendants": {
+                    "XF505": {
+                      "content": "X"
+                    },
+                    "qXADo": {
+                      "content": "Twitter / X"
+                    },
+                    "m2Xh3": {
+                      "content": "@ta93abe"
+                    }
+                  }
+                },
+                {
+                  "id": "Ni9Kp",
+                  "type": "ref",
+                  "ref": "AnbBZ",
+                  "name": "link2",
+                  "descendants": {
+                    "XF505": {
+                      "content": "GH"
+                    },
+                    "qXADo": {
+                      "content": "GitHub"
+                    },
+                    "m2Xh3": {
+                      "content": "github.com/ta93abe"
+                    }
+                  }
+                },
+                {
+                  "id": "D0RtE",
+                  "type": "ref",
+                  "ref": "AnbBZ",
+                  "name": "link3",
+                  "descendants": {
+                    "XF505": {
+                      "content": "Z"
+                    },
+                    "qXADo": {
+                      "content": "Zenn"
+                    },
+                    "m2Xh3": {
+                      "content": "zenn.dev/ta93abe"
+                    }
+                  }
+                },
+                {
+                  "id": "aryaB",
+                  "type": "ref",
+                  "ref": "AnbBZ",
+                  "name": "link4",
+                  "descendants": {
+                    "XF505": {
+                      "content": "Li"
+                    },
+                    "qXADo": {
+                      "content": "LinkedIn"
+                    },
+                    "m2Xh3": {
+                      "content": "linkedin.com/in/ta93abe"
+                    }
+                  }
+                },
+                {
+                  "id": "9bpGY",
+                  "type": "ref",
+                  "ref": "AnbBZ",
+                  "name": "link5",
+                  "descendants": {
+                    "XF505": {
+                      "content": "SP"
+                    },
+                    "qXADo": {
+                      "content": "Speaker Deck"
+                    },
+                    "m2Xh3": {
+                      "content": "speakerdeck.com/ta93abe"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "M3Mcj",
+          "name": "linksFooter",
+          "width": "fill_container",
+          "fill": "$bg-gray",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-color"
+          },
+          "layout": "vertical",
+          "padding": 32,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "FWdOT",
+              "name": "footerText",
+              "fill": "$text-muted",
+              "content": "© 2024 ta93abe. All rights reserved.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "Ufekg",
+      "x": 6160,
+      "y": 0,
+      "name": "404 Page",
+      "width": 1440,
+      "height": 900,
+      "fill": "$bg-primary",
+      "justifyContent": "center",
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "frame",
+          "id": "f3zKE",
+          "name": "Error Content",
+          "layout": "vertical",
+          "gap": 32,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "hNDha",
+              "name": "error404",
+              "fill": "$purple-600",
+              "content": "404",
+              "fontFamily": "Inter",
+              "fontSize": 144,
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "bxLfF",
+              "name": "errorTitle",
+              "fill": "$text-primary",
+              "content": "ページが見つかりません",
+              "fontFamily": "Inter",
+              "fontSize": 32,
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "u6KwB",
+              "name": "errorDesc",
+              "fill": "$text-secondary",
+              "content": "お探しのページは存在しないか、移動または削除された可能性があります。",
+              "textAlign": "center",
+              "fontFamily": "Inter",
+              "fontSize": 16,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "73J9L",
+              "name": "Error Buttons",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "caCsJ",
+                  "name": "homeBtn",
+                  "fill": "$purple-600",
+                  "cornerRadius": 8,
+                  "padding": [
+                    12,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "d1IrF",
+                      "name": "homeBtnText",
+                      "fill": "#ffffff",
+                      "content": "ホームに戻る",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "lVZH0",
+                  "name": "backBtn",
+                  "fill": "transparent",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "thickness": 2,
+                    "fill": "$border-color"
+                  },
+                  "padding": [
+                    12,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "q8Rgd",
+                      "name": "backBtnText",
+                      "fill": "$text-secondary",
+                      "content": "前のページへ",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "mMSWO",
+              "name": "errorIcon",
+              "opacity": 0.2,
+              "content": "🔍",
+              "fontFamily": "Inter",
+              "fontSize": 64,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "17GiX",
+      "x": 7700,
+      "y": 0,
+      "name": "Tools Page",
+      "width": 1440,
+      "fill": "$bg-primary",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "PgBbR",
+          "name": "toolsHeader",
+          "width": "fill_container",
+          "fill": "$bg-surface",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-color"
+          },
+          "padding": [
+            16,
+            48
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "id": "XrFRn",
+              "type": "ref",
+              "ref": "v08Ll",
+              "name": "headerLogo"
+            },
+            {
+              "type": "frame",
+              "id": "7Vpel",
+              "name": "Nav Links",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "q5GOm",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Home",
+                  "name": "navHome"
+                },
+                {
+                  "id": "b4utd",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Works",
+                  "name": "navWorks"
+                },
+                {
+                  "id": "cicO9",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Blog",
+                  "name": "navBlog"
+                },
+                {
+                  "id": "aYxOg",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Links",
+                  "name": "navLinks"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "T4wN6",
+          "name": "Tools Main",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            48,
+            96
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "qnXy2",
+              "name": "toolsTitle",
+              "fill": "$text-primary",
+              "content": "Tools",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "f1Dng",
+              "name": "toolsDesc",
+              "fill": "$text-secondary",
+              "content": "普段の開発で使用しているCLIツールやアプリケーションの一覧です。",
+              "fontFamily": "Inter",
+              "fontSize": 16,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "frxDx",
+              "name": "Stats Row",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "0zhxN",
+                  "name": "stat1",
+                  "width": 200,
+                  "fill": "$slate-50",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "$border-color"
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 24,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Sdv0s",
+                      "name": "stat1Num",
+                      "fill": "$blue-600",
+                      "content": "150+",
+                      "fontFamily": "Inter",
+                      "fontSize": 32,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "KCQxh",
+                      "name": "stat1Label",
+                      "fill": "$text-secondary",
+                      "content": "ツール総数",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "hh37c",
+                  "name": "stat2",
+                  "width": 200,
+                  "fill": "$slate-50",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "$border-color"
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 24,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "hUDnG",
+                      "name": "stat2Num",
+                      "fill": "$green-600",
+                      "content": "28",
+                      "fontFamily": "Inter",
+                      "fontSize": 32,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "nOm5y",
+                      "name": "stat2Label",
+                      "fill": "$text-secondary",
+                      "content": "カテゴリ数",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "qwIs9",
+                  "name": "stat3",
+                  "width": 200,
+                  "fill": "$slate-50",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "$border-color"
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 24,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "kvESt",
+                      "name": "stat3Num",
+                      "fill": "$purple-600",
+                      "content": "100%",
+                      "fontFamily": "Inter",
+                      "fontSize": 32,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Ww02p",
+                      "name": "stat3Label",
+                      "fill": "$text-secondary",
+                      "content": "Nix管理率",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "3Q2d7",
+              "name": "Category Shell",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "0ravh",
+                  "name": "cat1Title",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "fGIhU",
+                      "name": "cat1Icon",
+                      "content": "🐚",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "iSITl",
+                      "name": "cat1Name",
+                      "fill": "$text-primary",
+                      "content": "シェル・ターミナル",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "vGiRT",
+                      "name": "cat1Count",
+                      "fill": "$text-muted",
+                      "content": "(4)",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "4GpdA",
+                  "name": "Tools Grid",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "id": "vXW2T",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "tool1",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Fish"
+                        },
+                        "qoMv0": {
+                          "content": "シンタックスハイライトと強力な補完機能を持つモダンなシェル"
+                        },
+                        "axro8": {
+                          "content": "fishshell.com"
+                        }
+                      }
+                    },
+                    {
+                      "id": "u7pM6",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "tool2",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Starship"
+                        },
+                        "qoMv0": {
+                          "content": "高速でカスタマイズ可能なクロスシェルプロンプト"
+                        },
+                        "axro8": {
+                          "content": "starship.rs"
+                        }
+                      }
+                    },
+                    {
+                      "id": "JheSb",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "tool3",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Ghostty"
+                        },
+                        "qoMv0": {
+                          "content": "高速でGPUアクセラレーション対応のターミナルエミュレータ"
+                        },
+                        "axro8": {
+                          "content": "ghostty.org"
+                        }
+                      }
+                    },
+                    {
+                      "id": "uPQ9T",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "tool4",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Zellij"
+                        },
+                        "qoMv0": {
+                          "content": "Vim風キーバインドを持つターミナルマルチプレクサ"
+                        },
+                        "axro8": {
+                          "content": "zellij.dev"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "JT7q0",
+              "name": "Category IDE",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "7zf8v",
+                  "name": "cat2Title",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "IXFC2",
+                      "name": "cat2Icon",
+                      "content": "💻",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "mxfmd",
+                      "name": "cat2Name",
+                      "fill": "$text-primary",
+                      "content": "IDE・エディタ",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ib3I7",
+                      "name": "cat2Count",
+                      "fill": "$text-muted",
+                      "content": "(4)",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KBpNX",
+                  "name": "IDE Grid",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "id": "IDpsT",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "ide1",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "VS Code"
+                        },
+                        "qoMv0": {
+                          "content": "マイクロソフトの強力なコードエディタ"
+                        },
+                        "axro8": {
+                          "content": "code.visualstudio.com"
+                        }
+                      }
+                    },
+                    {
+                      "id": "rSIGI",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "ide2",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Cursor"
+                        },
+                        "qoMv0": {
+                          "content": "AI統合型のコードエディタ"
+                        },
+                        "axro8": {
+                          "content": "cursor.sh"
+                        }
+                      }
+                    },
+                    {
+                      "id": "IhAaT",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "ide3",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Zed"
+                        },
+                        "qoMv0": {
+                          "content": "高速で協調作業に最適化されたコードエディタ"
+                        },
+                        "axro8": {
+                          "content": "zed.dev"
+                        }
+                      }
+                    },
+                    {
+                      "id": "n3CbD",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "ide4",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Helix"
+                        },
+                        "qoMv0": {
+                          "content": "Rustで書かれたポストモダンなモーダルテキストエディタ"
+                        },
+                        "axro8": {
+                          "content": "helix-editor.com"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "kV7dR",
+          "name": "toolsFooter",
+          "width": "fill_container",
+          "fill": "$bg-gray",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-color"
+          },
+          "layout": "vertical",
+          "padding": 32,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "bQ9BL",
+              "name": "footerText",
+              "fill": "$text-muted",
+              "content": "© 2024 ta93abe. All rights reserved.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "bg-gray": {
+      "type": "color",
+      "value": "#f8fafc"
+    },
+    "bg-primary": {
+      "type": "color",
+      "value": "#fafafa"
+    },
+    "bg-surface": {
+      "type": "color",
+      "value": "#ffffff"
+    },
+    "border-color": {
+      "type": "color",
+      "value": "#e2e8f0"
+    },
+    "font-body": {
+      "type": "string",
+      "value": "Inter"
+    },
+    "font-display": {
+      "type": "string",
+      "value": "Shippori Mincho"
+    },
+    "primary-color": {
+      "type": "color",
+      "value": "#4f46e5"
+    },
+    "text-gray": {
+      "type": "color",
+      "value": "#9ca3af"
+    },
+    "text-muted": {
+      "type": "color",
+      "value": "#666666"
+    },
+    "text-primary": {
+      "type": "color",
+      "value": "#1a1a1a"
+    },
+    "text-secondary": {
+      "type": "color",
+      "value": "#555555"
+    },
+    "gray-100": {
+      "type": "color",
+      "value": "#f3f4f6"
+    },
+    "gray-200": {
+      "type": "color",
+      "value": "#e5e7eb"
+    },
+    "gray-300": {
+      "type": "color",
+      "value": "#d1d5db"
+    },
+    "gray-400": {
+      "type": "color",
+      "value": "#9ca3af"
+    },
+    "gray-50": {
+      "type": "color",
+      "value": "#f9fafb"
+    },
+    "gray-500": {
+      "type": "color",
+      "value": "#6b7280"
+    },
+    "gray-600": {
+      "type": "color",
+      "value": "#4b5563"
+    },
+    "gray-700": {
+      "type": "color",
+      "value": "#374151"
+    },
+    "gray-800": {
+      "type": "color",
+      "value": "#1f2937"
+    },
+    "gray-900": {
+      "type": "color",
+      "value": "#111827"
+    },
+    "gray-950": {
+      "type": "color",
+      "value": "#030712"
+    },
+    "neutral-100": {
+      "type": "color",
+      "value": "#f5f5f5"
+    },
+    "neutral-200": {
+      "type": "color",
+      "value": "#e5e5e5"
+    },
+    "neutral-300": {
+      "type": "color",
+      "value": "#d4d4d4"
+    },
+    "neutral-400": {
+      "type": "color",
+      "value": "#a3a3a3"
+    },
+    "neutral-50": {
+      "type": "color",
+      "value": "#fafafa"
+    },
+    "neutral-500": {
+      "type": "color",
+      "value": "#737373"
+    },
+    "neutral-600": {
+      "type": "color",
+      "value": "#525252"
+    },
+    "neutral-700": {
+      "type": "color",
+      "value": "#404040"
+    },
+    "neutral-800": {
+      "type": "color",
+      "value": "#262626"
+    },
+    "neutral-900": {
+      "type": "color",
+      "value": "#171717"
+    },
+    "neutral-950": {
+      "type": "color",
+      "value": "#0a0a0a"
+    },
+    "slate-100": {
+      "type": "color",
+      "value": "#f1f5f9"
+    },
+    "slate-200": {
+      "type": "color",
+      "value": "#e2e8f0"
+    },
+    "slate-300": {
+      "type": "color",
+      "value": "#cbd5e1"
+    },
+    "slate-400": {
+      "type": "color",
+      "value": "#94a3b8"
+    },
+    "slate-50": {
+      "type": "color",
+      "value": "#f8fafc"
+    },
+    "slate-500": {
+      "type": "color",
+      "value": "#64748b"
+    },
+    "slate-600": {
+      "type": "color",
+      "value": "#475569"
+    },
+    "slate-700": {
+      "type": "color",
+      "value": "#334155"
+    },
+    "slate-800": {
+      "type": "color",
+      "value": "#1e293b"
+    },
+    "slate-900": {
+      "type": "color",
+      "value": "#0f172a"
+    },
+    "slate-950": {
+      "type": "color",
+      "value": "#020617"
+    },
+    "stone-100": {
+      "type": "color",
+      "value": "#f5f5f4"
+    },
+    "stone-200": {
+      "type": "color",
+      "value": "#e7e5e4"
+    },
+    "stone-300": {
+      "type": "color",
+      "value": "#d6d3d1"
+    },
+    "stone-400": {
+      "type": "color",
+      "value": "#a8a29e"
+    },
+    "stone-50": {
+      "type": "color",
+      "value": "#fafaf9"
+    },
+    "stone-500": {
+      "type": "color",
+      "value": "#78716c"
+    },
+    "stone-600": {
+      "type": "color",
+      "value": "#57534e"
+    },
+    "stone-700": {
+      "type": "color",
+      "value": "#44403c"
+    },
+    "stone-800": {
+      "type": "color",
+      "value": "#292524"
+    },
+    "stone-900": {
+      "type": "color",
+      "value": "#1c1917"
+    },
+    "stone-950": {
+      "type": "color",
+      "value": "#0c0a09"
+    },
+    "zinc-100": {
+      "type": "color",
+      "value": "#f4f4f5"
+    },
+    "zinc-200": {
+      "type": "color",
+      "value": "#e4e4e7"
+    },
+    "zinc-300": {
+      "type": "color",
+      "value": "#d4d4d8"
+    },
+    "zinc-400": {
+      "type": "color",
+      "value": "#a1a1aa"
+    },
+    "zinc-50": {
+      "type": "color",
+      "value": "#fafafa"
+    },
+    "zinc-500": {
+      "type": "color",
+      "value": "#71717a"
+    },
+    "zinc-600": {
+      "type": "color",
+      "value": "#52525b"
+    },
+    "zinc-700": {
+      "type": "color",
+      "value": "#3f3f46"
+    },
+    "zinc-800": {
+      "type": "color",
+      "value": "#27272a"
+    },
+    "zinc-900": {
+      "type": "color",
+      "value": "#18181b"
+    },
+    "zinc-950": {
+      "type": "color",
+      "value": "#09090b"
+    },
+    "amber-100": {
+      "type": "color",
+      "value": "#fef3c7"
+    },
+    "amber-200": {
+      "type": "color",
+      "value": "#fde68a"
+    },
+    "amber-300": {
+      "type": "color",
+      "value": "#fcd34d"
+    },
+    "amber-400": {
+      "type": "color",
+      "value": "#fbbf24"
+    },
+    "amber-50": {
+      "type": "color",
+      "value": "#fffbeb"
+    },
+    "amber-500": {
+      "type": "color",
+      "value": "#f59e0b"
+    },
+    "amber-600": {
+      "type": "color",
+      "value": "#d97706"
+    },
+    "amber-700": {
+      "type": "color",
+      "value": "#b45309"
+    },
+    "amber-800": {
+      "type": "color",
+      "value": "#92400e"
+    },
+    "amber-900": {
+      "type": "color",
+      "value": "#78350f"
+    },
+    "amber-950": {
+      "type": "color",
+      "value": "#451a03"
+    },
+    "green-100": {
+      "type": "color",
+      "value": "#dcfce7"
+    },
+    "green-200": {
+      "type": "color",
+      "value": "#bbf7d0"
+    },
+    "green-300": {
+      "type": "color",
+      "value": "#86efac"
+    },
+    "green-400": {
+      "type": "color",
+      "value": "#4ade80"
+    },
+    "green-50": {
+      "type": "color",
+      "value": "#f0fdf4"
+    },
+    "green-500": {
+      "type": "color",
+      "value": "#22c55e"
+    },
+    "green-600": {
+      "type": "color",
+      "value": "#16a34a"
+    },
+    "green-700": {
+      "type": "color",
+      "value": "#15803d"
+    },
+    "green-800": {
+      "type": "color",
+      "value": "#166534"
+    },
+    "green-900": {
+      "type": "color",
+      "value": "#14532d"
+    },
+    "green-950": {
+      "type": "color",
+      "value": "#052e16"
+    },
+    "lime-100": {
+      "type": "color",
+      "value": "#ecfccb"
+    },
+    "lime-200": {
+      "type": "color",
+      "value": "#d9f99d"
+    },
+    "lime-300": {
+      "type": "color",
+      "value": "#bef264"
+    },
+    "lime-400": {
+      "type": "color",
+      "value": "#a3e635"
+    },
+    "lime-50": {
+      "type": "color",
+      "value": "#f7fee7"
+    },
+    "lime-500": {
+      "type": "color",
+      "value": "#84cc16"
+    },
+    "lime-600": {
+      "type": "color",
+      "value": "#65a30d"
+    },
+    "lime-700": {
+      "type": "color",
+      "value": "#4d7c0f"
+    },
+    "lime-800": {
+      "type": "color",
+      "value": "#3f6212"
+    },
+    "lime-900": {
+      "type": "color",
+      "value": "#365314"
+    },
+    "lime-950": {
+      "type": "color",
+      "value": "#1a2e05"
+    },
+    "orange-100": {
+      "type": "color",
+      "value": "#ffedd5"
+    },
+    "orange-200": {
+      "type": "color",
+      "value": "#fed7aa"
+    },
+    "orange-300": {
+      "type": "color",
+      "value": "#fdba74"
+    },
+    "orange-400": {
+      "type": "color",
+      "value": "#fb923c"
+    },
+    "orange-50": {
+      "type": "color",
+      "value": "#fff7ed"
+    },
+    "orange-500": {
+      "type": "color",
+      "value": "#f97316"
+    },
+    "orange-600": {
+      "type": "color",
+      "value": "#ea580c"
+    },
+    "orange-700": {
+      "type": "color",
+      "value": "#c2410c"
+    },
+    "orange-800": {
+      "type": "color",
+      "value": "#9a3412"
+    },
+    "orange-900": {
+      "type": "color",
+      "value": "#7c2d12"
+    },
+    "orange-950": {
+      "type": "color",
+      "value": "#431407"
+    },
+    "red-100": {
+      "type": "color",
+      "value": "#fee2e2"
+    },
+    "red-200": {
+      "type": "color",
+      "value": "#fecaca"
+    },
+    "red-300": {
+      "type": "color",
+      "value": "#fca5a5"
+    },
+    "red-400": {
+      "type": "color",
+      "value": "#f87171"
+    },
+    "red-50": {
+      "type": "color",
+      "value": "#fef2f2"
+    },
+    "red-500": {
+      "type": "color",
+      "value": "#ef4444"
+    },
+    "red-600": {
+      "type": "color",
+      "value": "#dc2626"
+    },
+    "red-700": {
+      "type": "color",
+      "value": "#b91c1c"
+    },
+    "red-800": {
+      "type": "color",
+      "value": "#991b1b"
+    },
+    "red-900": {
+      "type": "color",
+      "value": "#7f1d1d"
+    },
+    "red-950": {
+      "type": "color",
+      "value": "#450a0a"
+    },
+    "yellow-100": {
+      "type": "color",
+      "value": "#fef9c3"
+    },
+    "yellow-200": {
+      "type": "color",
+      "value": "#fef08a"
+    },
+    "yellow-300": {
+      "type": "color",
+      "value": "#fde047"
+    },
+    "yellow-400": {
+      "type": "color",
+      "value": "#facc15"
+    },
+    "yellow-50": {
+      "type": "color",
+      "value": "#fefce8"
+    },
+    "yellow-500": {
+      "type": "color",
+      "value": "#eab308"
+    },
+    "yellow-600": {
+      "type": "color",
+      "value": "#ca8a04"
+    },
+    "yellow-700": {
+      "type": "color",
+      "value": "#a16207"
+    },
+    "yellow-800": {
+      "type": "color",
+      "value": "#854d0e"
+    },
+    "yellow-900": {
+      "type": "color",
+      "value": "#713f12"
+    },
+    "yellow-950": {
+      "type": "color",
+      "value": "#422006"
+    },
+    "blue-100": {
+      "type": "color",
+      "value": "#dbeafe"
+    },
+    "blue-200": {
+      "type": "color",
+      "value": "#bfdbfe"
+    },
+    "blue-300": {
+      "type": "color",
+      "value": "#93c5fd"
+    },
+    "blue-400": {
+      "type": "color",
+      "value": "#60a5fa"
+    },
+    "blue-50": {
+      "type": "color",
+      "value": "#eff6ff"
+    },
+    "blue-500": {
+      "type": "color",
+      "value": "#3b82f6"
+    },
+    "blue-600": {
+      "type": "color",
+      "value": "#2563eb"
+    },
+    "blue-700": {
+      "type": "color",
+      "value": "#1d4ed8"
+    },
+    "blue-800": {
+      "type": "color",
+      "value": "#1e40af"
+    },
+    "blue-900": {
+      "type": "color",
+      "value": "#1e3a8a"
+    },
+    "blue-950": {
+      "type": "color",
+      "value": "#172554"
+    },
+    "cyan-100": {
+      "type": "color",
+      "value": "#cffafe"
+    },
+    "cyan-200": {
+      "type": "color",
+      "value": "#a5f3fc"
+    },
+    "cyan-300": {
+      "type": "color",
+      "value": "#67e8f9"
+    },
+    "cyan-400": {
+      "type": "color",
+      "value": "#22d3ee"
+    },
+    "cyan-50": {
+      "type": "color",
+      "value": "#ecfeff"
+    },
+    "cyan-500": {
+      "type": "color",
+      "value": "#06b6d4"
+    },
+    "cyan-600": {
+      "type": "color",
+      "value": "#0891b2"
+    },
+    "cyan-700": {
+      "type": "color",
+      "value": "#0e7490"
+    },
+    "cyan-800": {
+      "type": "color",
+      "value": "#155e75"
+    },
+    "cyan-900": {
+      "type": "color",
+      "value": "#164e63"
+    },
+    "cyan-950": {
+      "type": "color",
+      "value": "#083344"
+    },
+    "emerald-100": {
+      "type": "color",
+      "value": "#d1fae5"
+    },
+    "emerald-200": {
+      "type": "color",
+      "value": "#a7f3d0"
+    },
+    "emerald-300": {
+      "type": "color",
+      "value": "#6ee7b7"
+    },
+    "emerald-400": {
+      "type": "color",
+      "value": "#34d399"
+    },
+    "emerald-50": {
+      "type": "color",
+      "value": "#ecfdf5"
+    },
+    "emerald-500": {
+      "type": "color",
+      "value": "#10b981"
+    },
+    "emerald-600": {
+      "type": "color",
+      "value": "#059669"
+    },
+    "emerald-700": {
+      "type": "color",
+      "value": "#047857"
+    },
+    "emerald-800": {
+      "type": "color",
+      "value": "#065f46"
+    },
+    "emerald-900": {
+      "type": "color",
+      "value": "#064e3b"
+    },
+    "emerald-950": {
+      "type": "color",
+      "value": "#022c22"
+    },
+    "sky-100": {
+      "type": "color",
+      "value": "#e0f2fe"
+    },
+    "sky-200": {
+      "type": "color",
+      "value": "#bae6fd"
+    },
+    "sky-300": {
+      "type": "color",
+      "value": "#7dd3fc"
+    },
+    "sky-400": {
+      "type": "color",
+      "value": "#38bdf8"
+    },
+    "sky-50": {
+      "type": "color",
+      "value": "#f0f9ff"
+    },
+    "sky-500": {
+      "type": "color",
+      "value": "#0ea5e9"
+    },
+    "sky-600": {
+      "type": "color",
+      "value": "#0284c7"
+    },
+    "sky-700": {
+      "type": "color",
+      "value": "#0369a1"
+    },
+    "sky-800": {
+      "type": "color",
+      "value": "#075985"
+    },
+    "sky-900": {
+      "type": "color",
+      "value": "#0c4a6e"
+    },
+    "sky-950": {
+      "type": "color",
+      "value": "#082f49"
+    },
+    "teal-100": {
+      "type": "color",
+      "value": "#ccfbf1"
+    },
+    "teal-200": {
+      "type": "color",
+      "value": "#99f6e4"
+    },
+    "teal-300": {
+      "type": "color",
+      "value": "#5eead4"
+    },
+    "teal-400": {
+      "type": "color",
+      "value": "#2dd4bf"
+    },
+    "teal-50": {
+      "type": "color",
+      "value": "#f0fdfa"
+    },
+    "teal-500": {
+      "type": "color",
+      "value": "#14b8a6"
+    },
+    "teal-600": {
+      "type": "color",
+      "value": "#0d9488"
+    },
+    "teal-700": {
+      "type": "color",
+      "value": "#0f766e"
+    },
+    "teal-800": {
+      "type": "color",
+      "value": "#115e59"
+    },
+    "teal-900": {
+      "type": "color",
+      "value": "#134e4a"
+    },
+    "teal-950": {
+      "type": "color",
+      "value": "#042f2e"
+    },
+    "fuchsia-100": {
+      "type": "color",
+      "value": "#fae8ff"
+    },
+    "fuchsia-200": {
+      "type": "color",
+      "value": "#f5d0fe"
+    },
+    "fuchsia-300": {
+      "type": "color",
+      "value": "#f0abfc"
+    },
+    "fuchsia-400": {
+      "type": "color",
+      "value": "#e879f9"
+    },
+    "fuchsia-50": {
+      "type": "color",
+      "value": "#fdf4ff"
+    },
+    "fuchsia-500": {
+      "type": "color",
+      "value": "#d946ef"
+    },
+    "fuchsia-600": {
+      "type": "color",
+      "value": "#c026d3"
+    },
+    "fuchsia-700": {
+      "type": "color",
+      "value": "#a21caf"
+    },
+    "fuchsia-800": {
+      "type": "color",
+      "value": "#86198f"
+    },
+    "fuchsia-900": {
+      "type": "color",
+      "value": "#701a75"
+    },
+    "fuchsia-950": {
+      "type": "color",
+      "value": "#4a044e"
+    },
+    "indigo-100": {
+      "type": "color",
+      "value": "#e0e7ff"
+    },
+    "indigo-200": {
+      "type": "color",
+      "value": "#c7d2fe"
+    },
+    "indigo-300": {
+      "type": "color",
+      "value": "#a5b4fc"
+    },
+    "indigo-400": {
+      "type": "color",
+      "value": "#818cf8"
+    },
+    "indigo-50": {
+      "type": "color",
+      "value": "#eef2ff"
+    },
+    "indigo-500": {
+      "type": "color",
+      "value": "#6366f1"
+    },
+    "indigo-600": {
+      "type": "color",
+      "value": "#4f46e5"
+    },
+    "indigo-700": {
+      "type": "color",
+      "value": "#4338ca"
+    },
+    "indigo-800": {
+      "type": "color",
+      "value": "#3730a3"
+    },
+    "indigo-900": {
+      "type": "color",
+      "value": "#312e81"
+    },
+    "indigo-950": {
+      "type": "color",
+      "value": "#1e1b4b"
+    },
+    "pink-100": {
+      "type": "color",
+      "value": "#fce7f3"
+    },
+    "pink-200": {
+      "type": "color",
+      "value": "#fbcfe8"
+    },
+    "pink-300": {
+      "type": "color",
+      "value": "#f9a8d4"
+    },
+    "pink-400": {
+      "type": "color",
+      "value": "#f472b6"
+    },
+    "pink-50": {
+      "type": "color",
+      "value": "#fdf2f8"
+    },
+    "pink-500": {
+      "type": "color",
+      "value": "#ec4899"
+    },
+    "pink-600": {
+      "type": "color",
+      "value": "#db2777"
+    },
+    "pink-700": {
+      "type": "color",
+      "value": "#be185d"
+    },
+    "pink-800": {
+      "type": "color",
+      "value": "#9d174d"
+    },
+    "pink-900": {
+      "type": "color",
+      "value": "#831843"
+    },
+    "pink-950": {
+      "type": "color",
+      "value": "#500724"
+    },
+    "purple-100": {
+      "type": "color",
+      "value": "#f3e8ff"
+    },
+    "purple-200": {
+      "type": "color",
+      "value": "#e9d5ff"
+    },
+    "purple-300": {
+      "type": "color",
+      "value": "#d8b4fe"
+    },
+    "purple-400": {
+      "type": "color",
+      "value": "#c084fc"
+    },
+    "purple-50": {
+      "type": "color",
+      "value": "#faf5ff"
+    },
+    "purple-500": {
+      "type": "color",
+      "value": "#a855f7"
+    },
+    "purple-600": {
+      "type": "color",
+      "value": "#9333ea"
+    },
+    "purple-700": {
+      "type": "color",
+      "value": "#7e22ce"
+    },
+    "purple-800": {
+      "type": "color",
+      "value": "#6b21a8"
+    },
+    "purple-900": {
+      "type": "color",
+      "value": "#581c87"
+    },
+    "purple-950": {
+      "type": "color",
+      "value": "#3b0764"
+    },
+    "rose-100": {
+      "type": "color",
+      "value": "#ffe4e6"
+    },
+    "rose-200": {
+      "type": "color",
+      "value": "#fecdd3"
+    },
+    "rose-300": {
+      "type": "color",
+      "value": "#fda4af"
+    },
+    "rose-400": {
+      "type": "color",
+      "value": "#fb7185"
+    },
+    "rose-50": {
+      "type": "color",
+      "value": "#fff1f2"
+    },
+    "rose-500": {
+      "type": "color",
+      "value": "#f43f5e"
+    },
+    "rose-600": {
+      "type": "color",
+      "value": "#e11d48"
+    },
+    "rose-700": {
+      "type": "color",
+      "value": "#be123c"
+    },
+    "rose-800": {
+      "type": "color",
+      "value": "#9f1239"
+    },
+    "rose-900": {
+      "type": "color",
+      "value": "#881337"
+    },
+    "rose-950": {
+      "type": "color",
+      "value": "#4c0519"
+    },
+    "violet-100": {
+      "type": "color",
+      "value": "#ede9fe"
+    },
+    "violet-200": {
+      "type": "color",
+      "value": "#ddd6fe"
+    },
+    "violet-300": {
+      "type": "color",
+      "value": "#c4b5fd"
+    },
+    "violet-400": {
+      "type": "color",
+      "value": "#a78bfa"
+    },
+    "violet-50": {
+      "type": "color",
+      "value": "#f5f3ff"
+    },
+    "violet-500": {
+      "type": "color",
+      "value": "#8b5cf6"
+    },
+    "violet-600": {
+      "type": "color",
+      "value": "#7c3aed"
+    },
+    "violet-700": {
+      "type": "color",
+      "value": "#6d28d9"
+    },
+    "violet-800": {
+      "type": "color",
+      "value": "#5b21b6"
+    },
+    "violet-900": {
+      "type": "color",
+      "value": "#4c1d95"
+    },
+    "violet-950": {
+      "type": "color",
+      "value": "#2e1065"
+    },
+    "radius-2xl": {
+      "type": "number",
+      "value": 16
+    },
+    "radius-3xl": {
+      "type": "number",
+      "value": 24
+    },
+    "radius-4xl": {
+      "type": "number",
+      "value": 32
+    },
+    "radius-full": {
+      "type": "number",
+      "value": 9999
+    },
+    "radius-lg": {
+      "type": "number",
+      "value": 8
+    },
+    "radius-md": {
+      "type": "number",
+      "value": 6
+    },
+    "radius-none": {
+      "type": "number",
+      "value": 0
+    },
+    "radius-sm": {
+      "type": "number",
+      "value": 4
+    },
+    "radius-xl": {
+      "type": "number",
+      "value": 12
+    },
+    "radius-xs": {
+      "type": "number",
+      "value": 2
+    },
+    "spacing-0": {
+      "type": "number",
+      "value": 0
+    },
+    "spacing-0.5": {
+      "type": "number",
+      "value": 2
+    },
+    "spacing-1": {
+      "type": "number",
+      "value": 4
+    },
+    "spacing-1.5": {
+      "type": "number",
+      "value": 6
+    },
+    "spacing-10": {
+      "type": "number",
+      "value": 40
+    },
+    "spacing-11": {
+      "type": "number",
+      "value": 44
+    },
+    "spacing-12": {
+      "type": "number",
+      "value": 48
+    },
+    "spacing-14": {
+      "type": "number",
+      "value": 56
+    },
+    "spacing-16": {
+      "type": "number",
+      "value": 64
+    },
+    "spacing-2": {
+      "type": "number",
+      "value": 8
+    },
+    "spacing-2.5": {
+      "type": "number",
+      "value": 10
+    },
+    "spacing-20": {
+      "type": "number",
+      "value": 80
+    },
+    "spacing-24": {
+      "type": "number",
+      "value": 96
+    },
+    "spacing-28": {
+      "type": "number",
+      "value": 112
+    },
+    "spacing-3": {
+      "type": "number",
+      "value": 12
+    },
+    "spacing-3.5": {
+      "type": "number",
+      "value": 14
+    },
+    "spacing-32": {
+      "type": "number",
+      "value": 128
+    },
+    "spacing-36": {
+      "type": "number",
+      "value": 144
+    },
+    "spacing-4": {
+      "type": "number",
+      "value": 16
+    },
+    "spacing-40": {
+      "type": "number",
+      "value": 160
+    },
+    "spacing-44": {
+      "type": "number",
+      "value": 176
+    },
+    "spacing-48": {
+      "type": "number",
+      "value": 192
+    },
+    "spacing-5": {
+      "type": "number",
+      "value": 20
+    },
+    "spacing-52": {
+      "type": "number",
+      "value": 208
+    },
+    "spacing-56": {
+      "type": "number",
+      "value": 224
+    },
+    "spacing-6": {
+      "type": "number",
+      "value": 24
+    },
+    "spacing-60": {
+      "type": "number",
+      "value": 240
+    },
+    "spacing-64": {
+      "type": "number",
+      "value": 256
+    },
+    "spacing-7": {
+      "type": "number",
+      "value": 28
+    },
+    "spacing-72": {
+      "type": "number",
+      "value": 288
+    },
+    "spacing-8": {
+      "type": "number",
+      "value": 32
+    },
+    "spacing-80": {
+      "type": "number",
+      "value": 320
+    },
+    "spacing-9": {
+      "type": "number",
+      "value": 36
+    },
+    "spacing-96": {
+      "type": "number",
+      "value": 384
+    },
+    "spacing-px": {
+      "type": "number",
+      "value": 1
+    },
+    "text-2xl": {
+      "type": "number",
+      "value": 24
+    },
+    "text-3xl": {
+      "type": "number",
+      "value": 30
+    },
+    "text-4xl": {
+      "type": "number",
+      "value": 36
+    },
+    "text-5xl": {
+      "type": "number",
+      "value": 48
+    },
+    "text-6xl": {
+      "type": "number",
+      "value": 60
+    },
+    "text-7xl": {
+      "type": "number",
+      "value": 72
+    },
+    "text-8xl": {
+      "type": "number",
+      "value": 96
+    },
+    "text-9xl": {
+      "type": "number",
+      "value": 128
+    },
+    "text-base": {
+      "type": "number",
+      "value": 16
+    },
+    "text-lg": {
+      "type": "number",
+      "value": 18
+    },
+    "text-sm": {
+      "type": "number",
+      "value": 14
+    },
+    "text-xl": {
+      "type": "number",
+      "value": 20
+    },
+    "text-xs": {
+      "type": "number",
+      "value": 12
+    }
+  }
+}

--- a/design.pen
+++ b/design.pen
@@ -8,7 +8,7 @@
       "y": 0,
       "name": "Landing Page - Desktop",
       "width": 1440,
-      "fill": "$bg-primary",
+      "fill": "$stone-50",
       "layout": "vertical",
       "children": [
         {
@@ -16,15 +16,17 @@
           "id": "3rI5l",
           "name": "Header",
           "width": "fill_container",
-          "fill": "$bg-surface",
+          "fill": "transparent",
           "stroke": {
             "align": "inside",
-            "thickness": 1,
-            "fill": "$border-color"
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$stone-200"
           },
           "padding": [
-            16,
-            48
+            20,
+            64
           ],
           "justifyContent": "space_between",
           "alignItems": "center",
@@ -39,7 +41,7 @@
               "type": "frame",
               "id": "KlPdv",
               "name": "Nav Links",
-              "gap": 32,
+              "gap": 40,
               "alignItems": "center",
               "children": [
                 {
@@ -79,10 +81,88 @@
           "id": "3NGtL",
           "name": "Hero Section",
           "width": "fill_container",
-          "height": 700,
-          "fill": "$bg-primary",
+          "height": 720,
+          "fill": [
+            {
+              "type": "gradient",
+              "gradientType": "radial",
+              "enabled": true,
+              "rotation": 0,
+              "size": {
+                "width": 1.2,
+                "height": 1.2
+              },
+              "colors": [
+                {
+                  "color": "$rose-50",
+                  "position": 0
+                },
+                {
+                  "color": "$stone-50",
+                  "position": 0.6
+                },
+                {
+                  "color": "$stone-100",
+                  "position": 1
+                }
+              ],
+              "center": {
+                "y": 0.4
+              }
+            },
+            {
+              "type": "gradient",
+              "gradientType": "radial",
+              "enabled": true,
+              "opacity": 0.5,
+              "rotation": 0,
+              "size": {
+                "width": 0.7,
+                "height": 0.9
+              },
+              "colors": [
+                {
+                  "color": "#fb718540",
+                  "position": 0
+                },
+                {
+                  "color": "#fb718500",
+                  "position": 1
+                }
+              ],
+              "center": {
+                "x": 0.1,
+                "y": 0.25
+              }
+            },
+            {
+              "type": "gradient",
+              "gradientType": "radial",
+              "enabled": true,
+              "opacity": 0.4,
+              "rotation": 0,
+              "size": {
+                "width": 0.6,
+                "height": 0.8
+              },
+              "colors": [
+                {
+                  "color": "#a78bfa30",
+                  "position": 0
+                },
+                {
+                  "color": "#a78bfa00",
+                  "position": 1
+                }
+              ],
+              "center": {
+                "x": 0.9,
+                "y": 0.75
+              }
+            }
+          ],
           "layout": "vertical",
-          "gap": 24,
+          "gap": 32,
           "padding": 32,
           "justifyContent": "center",
           "alignItems": "center",
@@ -91,27 +171,27 @@
               "type": "frame",
               "id": "uVoam",
               "name": "Greeting",
-              "fill": "$bg-surface",
-              "cornerRadius": 4,
+              "fill": "#FFFFFF",
+              "cornerRadius": 20,
               "stroke": {
                 "thickness": 1,
-                "fill": "$border-color"
+                "fill": "$rose-500"
               },
               "padding": [
                 8,
-                16
+                20
               ],
               "children": [
                 {
                   "type": "text",
                   "id": "5kGWC",
                   "name": "heroGreetingText",
-                  "fill": "$text-muted",
+                  "fill": "$rose-500",
                   "content": "Welcome to my portfolio",
                   "fontFamily": "Inter",
-                  "fontSize": 14,
-                  "fontWeight": "normal",
-                  "letterSpacing": 1
+                  "fontSize": 12,
+                  "fontWeight": "600",
+                  "letterSpacing": 3
                 }
               ]
             },
@@ -119,22 +199,24 @@
               "type": "text",
               "id": "h1vRb",
               "name": "Title",
-              "fill": "$text-primary",
+              "fill": "$stone-900",
               "content": "ta93abe",
               "lineHeight": 1,
               "fontFamily": "Shippori Mincho",
-              "fontSize": 144,
-              "fontWeight": "700"
+              "fontSize": 128,
+              "fontWeight": "800",
+              "letterSpacing": -2
             },
             {
               "type": "text",
               "id": "Mm5eC",
               "name": "Description",
-              "fill": "$text-secondary",
+              "fill": "$stone-500",
               "content": "Software Engineer & Creative Developer",
               "fontFamily": "Inter",
-              "fontSize": 24,
-              "fontWeight": "normal"
+              "fontSize": 20,
+              "fontWeight": "500",
+              "letterSpacing": 2
             },
             {
               "type": "frame",
@@ -164,14 +246,16 @@
           "id": "0hlj7",
           "name": "Footer",
           "width": "fill_container",
-          "fill": "$bg-gray",
+          "fill": "$stone-50",
           "stroke": {
             "align": "inside",
-            "thickness": 1,
-            "fill": "$border-color"
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$stone-200"
           },
           "layout": "vertical",
-          "padding": 32,
+          "padding": 24,
           "justifyContent": "center",
           "alignItems": "center",
           "children": [
@@ -179,11 +263,12 @@
               "type": "text",
               "id": "qgnCk",
               "name": "footerText",
-              "fill": "$text-muted",
+              "fill": "$stone-400",
               "content": "© 2024 ta93abe. All rights reserved.",
               "fontFamily": "Inter",
-              "fontSize": 14,
-              "fontWeight": "normal"
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "letterSpacing": 0.5
             }
           ]
         }
@@ -192,8 +277,8 @@
     {
       "type": "frame",
       "id": "gsNyF",
-      "x": 0,
-      "y": 1200,
+      "x": 1831,
+      "y": 6324,
       "name": "Design Tokens - Colors",
       "width": 1600,
       "fill": "#ffffff",
@@ -3261,8 +3346,8 @@
     {
       "type": "frame",
       "id": "oS6qb",
-      "x": 1700,
-      "y": 1200,
+      "x": 3620,
+      "y": 6324,
       "name": "Design Tokens - Spacing",
       "width": 1000,
       "height": 1400,
@@ -3915,8 +4000,8 @@
     {
       "type": "frame",
       "id": "zPpIB",
-      "x": 2800,
-      "y": 1200,
+      "x": 4779,
+      "y": 6324,
       "name": "Design Tokens - Typography",
       "width": 1000,
       "height": 1200,
@@ -4337,10 +4422,11 @@
     {
       "type": "frame",
       "id": "byyU1",
-      "x": 3900,
-      "y": 1200,
+      "x": 5958,
+      "y": 6324,
       "name": "Components Library",
-      "width": 1200,
+      "width": 2596,
+      "height": 2051,
       "fill": "#ffffff",
       "layout": "vertical",
       "gap": 48,
@@ -4526,11 +4612,11 @@
                   "id": "qIlVR",
                   "name": "Component/Button/Primary",
                   "reusable": true,
-                  "fill": "$text-primary",
-                  "cornerRadius": 9999,
+                  "fill": "$rose-500",
+                  "cornerRadius": 12,
                   "padding": [
-                    16,
-                    40
+                    14,
+                    32
                   ],
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -4539,11 +4625,12 @@
                       "type": "text",
                       "id": "0IKVR",
                       "name": "Label",
-                      "fill": "$bg-surface",
+                      "fill": "#FFFFFF",
                       "content": "View Works",
                       "fontFamily": "$font-body",
-                      "fontSize": 16,
-                      "fontWeight": "500"
+                      "fontSize": 14,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
                     }
                   ]
                 },
@@ -4553,14 +4640,14 @@
                   "name": "Component/Button/Secondary",
                   "reusable": true,
                   "fill": "transparent",
-                  "cornerRadius": 9999,
+                  "cornerRadius": 12,
                   "stroke": {
-                    "thickness": 2,
-                    "fill": "$text-primary"
+                    "thickness": 1.5,
+                    "fill": "$stone-900"
                   },
                   "padding": [
-                    16,
-                    40
+                    14,
+                    32
                   ],
                   "justifyContent": "center",
                   "alignItems": "center",
@@ -4569,11 +4656,12 @@
                       "type": "text",
                       "id": "MIU27",
                       "name": "Label",
-                      "fill": "$text-primary",
+                      "fill": "$stone-900",
                       "content": "Links",
                       "fontFamily": "$font-body",
-                      "fontSize": 16,
-                      "fontWeight": "500"
+                      "fontSize": 14,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
                     }
                   ]
                 },
@@ -4582,22 +4670,24 @@
                   "id": "FJk13",
                   "name": "Component/NavLink",
                   "reusable": true,
-                  "fill": "$text-primary",
+                  "fill": "$stone-500",
                   "content": "Link",
                   "fontFamily": "$font-body",
-                  "fontSize": 16,
-                  "fontWeight": "normal"
+                  "fontSize": 14,
+                  "fontWeight": "500",
+                  "letterSpacing": 0.5
                 },
                 {
                   "type": "text",
                   "id": "v08Ll",
                   "name": "Component/Logo",
                   "reusable": true,
-                  "fill": "$text-primary",
+                  "fill": "$stone-900",
                   "content": "ta93abe",
                   "fontFamily": "$font-display",
-                  "fontSize": 20,
-                  "fontWeight": "600"
+                  "fontSize": 18,
+                  "fontWeight": "700",
+                  "letterSpacing": -0.5
                 },
                 {
                   "type": "frame",
@@ -4907,6 +4997,129 @@
                   ]
                 }
               ]
+            },
+            {
+              "id": "G7bpH",
+              "type": "ref",
+              "ref": "JJp9T",
+              "name": "Component/Button/Secondary/Dark",
+              "fill": "transparent",
+              "stroke": {
+                "thickness": 1.5,
+                "fill": "$text-dark-primary"
+              },
+              "descendants": {
+                "MIU27": {
+                  "fill": "$text-dark-primary"
+                }
+              }
+            },
+            {
+              "id": "7xAoe",
+              "type": "ref",
+              "ref": "FJk13",
+              "name": "Component/NavLink/Dark",
+              "fill": "$text-dark-secondary"
+            },
+            {
+              "id": "q4N24",
+              "type": "ref",
+              "ref": "v08Ll",
+              "name": "Component/Logo/Dark",
+              "fill": "$text-dark-primary"
+            },
+            {
+              "id": "S0aRQ",
+              "type": "ref",
+              "ref": "ZaN91",
+              "name": "Component/WorkCard/Dark",
+              "fill": "$bg-dark-surface",
+              "stroke": {
+                "thickness": 1,
+                "fill": "$border-dark"
+              },
+              "descendants": {
+                "v9BuY": {
+                  "fill": "$bg-dark-elevated"
+                },
+                "pZN6e": {
+                  "fill": "$text-dark-primary"
+                },
+                "ZbNcE": {
+                  "fill": "$text-dark-secondary"
+                }
+              }
+            },
+            {
+              "id": "vWrT2",
+              "type": "ref",
+              "ref": "HaoZE",
+              "name": "Component/BlogPostItem/Dark",
+              "stroke": {
+                "thickness": 1,
+                "fill": "$border-dark"
+              },
+              "descendants": {
+                "NAuAh": {
+                  "fill": "$text-dark-muted"
+                },
+                "u2FXW": {
+                  "fill": "$text-dark-primary"
+                },
+                "1h9ql": {
+                  "fill": "$text-dark-secondary"
+                },
+                "AnY46": {
+                  "fill": "$bg-dark-elevated"
+                }
+              }
+            },
+            {
+              "id": "bwbvL",
+              "type": "ref",
+              "ref": "AnbBZ",
+              "name": "Component/SnsLinkItem/Dark",
+              "fill": "$bg-dark-surface",
+              "stroke": {
+                "thickness": 1,
+                "fill": "$border-dark"
+              },
+              "descendants": {
+                "gbq50": {
+                  "fill": "$bg-dark-elevated"
+                },
+                "XF505": {
+                  "fill": "$text-dark-secondary"
+                },
+                "qXADo": {
+                  "fill": "$text-dark-primary"
+                },
+                "m2Xh3": {
+                  "fill": "$text-dark-muted"
+                }
+              }
+            },
+            {
+              "id": "JhJhg",
+              "type": "ref",
+              "ref": "BndNx",
+              "name": "Component/ToolCard/Dark",
+              "fill": "$bg-dark-surface",
+              "stroke": {
+                "thickness": 1,
+                "fill": "$border-dark"
+              },
+              "descendants": {
+                "CdHXJ": {
+                  "fill": "$blue-400"
+                },
+                "qoMv0": {
+                  "fill": "$text-dark-secondary"
+                },
+                "axro8": {
+                  "fill": "$text-dark-muted"
+                }
+              }
             }
           ]
         }
@@ -6234,6 +6447,1602 @@
           ]
         }
       ]
+    },
+    {
+      "type": "frame",
+      "id": "IpYo5",
+      "x": 0,
+      "y": 4604,
+      "name": "Landing Page - Dark",
+      "width": 1440,
+      "fill": "$bg-dark-primary",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "qhwKW",
+          "name": "Header",
+          "width": "fill_container",
+          "fill": "transparent",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$border-dark"
+          },
+          "padding": [
+            20,
+            64
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "id": "Hw8lJ",
+              "type": "ref",
+              "ref": "v08Ll",
+              "name": "headerLogo"
+            },
+            {
+              "type": "frame",
+              "id": "oaUiF",
+              "name": "Nav Links",
+              "gap": 40,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "aXcNB",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Home",
+                  "name": "navHome"
+                },
+                {
+                  "id": "Ci3DB",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Works",
+                  "name": "navWorks"
+                },
+                {
+                  "id": "WHA7m",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Blog",
+                  "name": "navBlog"
+                },
+                {
+                  "id": "EnNho",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Links",
+                  "name": "navLinks"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "CSTTV",
+          "name": "Hero Section",
+          "width": "fill_container",
+          "height": 720,
+          "fill": [
+            {
+              "type": "gradient",
+              "gradientType": "radial",
+              "enabled": true,
+              "rotation": 0,
+              "size": {
+                "width": 1.2,
+                "height": 1.2
+              },
+              "colors": [
+                {
+                  "color": "#18181b",
+                  "position": 0
+                },
+                {
+                  "color": "#0a0a0a",
+                  "position": 0.6
+                },
+                {
+                  "color": "#09090b",
+                  "position": 1
+                }
+              ],
+              "center": {
+                "y": 0.4
+              }
+            },
+            {
+              "type": "gradient",
+              "gradientType": "radial",
+              "enabled": true,
+              "opacity": 0.5,
+              "rotation": 0,
+              "size": {
+                "width": 0.7,
+                "height": 0.9
+              },
+              "colors": [
+                {
+                  "color": "#be123c40",
+                  "position": 0
+                },
+                {
+                  "color": "#be123c00",
+                  "position": 1
+                }
+              ],
+              "center": {
+                "x": 0.1,
+                "y": 0.25
+              }
+            },
+            {
+              "type": "gradient",
+              "gradientType": "radial",
+              "enabled": true,
+              "opacity": 0.4,
+              "rotation": 0,
+              "size": {
+                "width": 0.6,
+                "height": 0.8
+              },
+              "colors": [
+                {
+                  "color": "#7c3aed30",
+                  "position": 0
+                },
+                {
+                  "color": "#7c3aed00",
+                  "position": 1
+                }
+              ],
+              "center": {
+                "x": 0.9,
+                "y": 0.75
+              }
+            }
+          ],
+          "layout": "vertical",
+          "gap": 32,
+          "padding": 32,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "OtxpK",
+              "name": "Greeting",
+              "fill": "$bg-dark-surface",
+              "cornerRadius": 20,
+              "stroke": {
+                "thickness": 1,
+                "fill": "$accent-dark-coral"
+              },
+              "padding": [
+                8,
+                20
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ikOhw",
+                  "name": "heroGreetingText",
+                  "fill": "$accent-dark-coral",
+                  "content": "Welcome to my portfolio",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600",
+                  "letterSpacing": 3
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "ppSzX",
+              "name": "Title",
+              "fill": "$text-dark-primary",
+              "content": "ta93abe",
+              "lineHeight": 1,
+              "fontFamily": "Shippori Mincho",
+              "fontSize": 128,
+              "fontWeight": "800",
+              "letterSpacing": -2
+            },
+            {
+              "type": "text",
+              "id": "AOFv2",
+              "name": "Description",
+              "fill": "$text-dark-secondary",
+              "content": "Software Engineer & Creative Developer",
+              "fontFamily": "Inter",
+              "fontSize": 20,
+              "fontWeight": "500",
+              "letterSpacing": 2
+            },
+            {
+              "type": "frame",
+              "id": "jolQ4",
+              "name": "CTA Buttons",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "PCbGG",
+                  "type": "ref",
+                  "ref": "qIlVR",
+                  "name": "ctaPrimary"
+                },
+                {
+                  "id": "mfFvs",
+                  "type": "ref",
+                  "ref": "JJp9T",
+                  "name": "ctaSecondary"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "EaB05",
+          "name": "Footer",
+          "width": "fill_container",
+          "fill": "$bg-dark-surface",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "top": 1
+            },
+            "fill": "$border-dark"
+          },
+          "layout": "vertical",
+          "padding": 24,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "BkJiv",
+              "name": "footerText",
+              "fill": "$text-dark-muted",
+              "content": "© 2024 ta93abe. All rights reserved.",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal",
+              "letterSpacing": 0.5
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "5baOa",
+      "x": 1540,
+      "y": 4604,
+      "name": "Works Page - Dark",
+      "width": 1440,
+      "fill": "$bg-dark-primary",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "xzwuz",
+          "name": "worksHeader",
+          "width": "fill_container",
+          "fill": "$bg-dark-surface",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-dark"
+          },
+          "padding": [
+            16,
+            48
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "id": "39OZt",
+              "type": "ref",
+              "ref": "v08Ll",
+              "name": "headerLogo"
+            },
+            {
+              "type": "frame",
+              "id": "Y6jBO",
+              "name": "Nav Links",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "NLLGm",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Home",
+                  "name": "navHome"
+                },
+                {
+                  "id": "2OAtR",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Works",
+                  "name": "navWorks"
+                },
+                {
+                  "id": "SbsVr",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Blog",
+                  "name": "navBlog"
+                },
+                {
+                  "id": "yMtIL",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Links",
+                  "name": "navLinks"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "FGJXF",
+          "name": "Works Main",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            48,
+            96
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "jxhzJ",
+              "name": "worksTitle",
+              "fill": "$text-dark-primary",
+              "content": "Works",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "700"
+            },
+            {
+              "type": "frame",
+              "id": "hPJwi",
+              "name": "Works Grid",
+              "width": "fill_container",
+              "gap": 24,
+              "children": [
+                {
+                  "id": "LdUat",
+                  "type": "ref",
+                  "ref": "ZaN91",
+                  "name": "card1",
+                  "descendants": {
+                    "pZN6e": {
+                      "content": "Portfolio Website"
+                    },
+                    "ZbNcE": {
+                      "content": "Astro + Tailwind CSS で構築した個人サイト"
+                    }
+                  }
+                },
+                {
+                  "id": "NjcSJ",
+                  "type": "ref",
+                  "ref": "ZaN91",
+                  "name": "card2",
+                  "descendants": {
+                    "pZN6e": {
+                      "content": "E-Commerce Platform"
+                    },
+                    "ZbNcE": {
+                      "content": "Next.js ベースのECサイト構築"
+                    }
+                  }
+                },
+                {
+                  "id": "Ouewv",
+                  "type": "ref",
+                  "ref": "ZaN91",
+                  "name": "card3",
+                  "descendants": {
+                    "pZN6e": {
+                      "content": "Design System"
+                    },
+                    "ZbNcE": {
+                      "content": "社内向けデザインシステムの設計・実装"
+                    }
+                  }
+                },
+                {
+                  "id": "iT8A3",
+                  "type": "ref",
+                  "ref": "ZaN91",
+                  "name": "card4",
+                  "descendants": {
+                    "pZN6e": {
+                      "content": "Mobile App"
+                    },
+                    "ZbNcE": {
+                      "content": "React Native クロスプラットフォームアプリ"
+                    }
+                  }
+                },
+                {
+                  "id": "xi3mf",
+                  "type": "ref",
+                  "ref": "ZaN91",
+                  "name": "card5",
+                  "descendants": {
+                    "pZN6e": {
+                      "content": "Analytics Dashboard"
+                    },
+                    "ZbNcE": {
+                      "content": "データ可視化ダッシュボードの開発"
+                    }
+                  }
+                },
+                {
+                  "id": "8LpYm",
+                  "type": "ref",
+                  "ref": "ZaN91",
+                  "name": "card6",
+                  "descendants": {
+                    "pZN6e": {
+                      "content": "CLI Tool"
+                    },
+                    "ZbNcE": {
+                      "content": "Node.js 製の開発支援ツール"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "LVZXH",
+          "name": "worksFooter",
+          "width": "fill_container",
+          "fill": "$bg-dark-muted",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-dark"
+          },
+          "layout": "vertical",
+          "padding": 32,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "TzZWs",
+              "name": "footerText",
+              "fill": "$text-dark-muted",
+              "content": "© 2024 ta93abe. All rights reserved.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "RxVTN",
+      "x": 3080,
+      "y": 3351,
+      "name": "Blog Page - Dark",
+      "width": 1440,
+      "fill": "$bg-dark-primary",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Avjbk",
+          "name": "blogHeader",
+          "width": "fill_container",
+          "fill": "$bg-dark-surface",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-dark"
+          },
+          "padding": [
+            16,
+            48
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "id": "fr8Gl",
+              "type": "ref",
+              "ref": "v08Ll",
+              "name": "headerLogo"
+            },
+            {
+              "type": "frame",
+              "id": "ldUXt",
+              "name": "Nav Links",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "6wQNz",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Home",
+                  "name": "navHome"
+                },
+                {
+                  "id": "sDZR8",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Works",
+                  "name": "navWorks"
+                },
+                {
+                  "id": "ETdg7",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Blog",
+                  "name": "navBlog"
+                },
+                {
+                  "id": "8MDVV",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Links",
+                  "name": "navLinks"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "U0jVO",
+          "name": "Blog Main",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            48,
+            200
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "99cmM",
+              "name": "Title Row",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "OWEyb",
+                  "name": "blogTitle",
+                  "fill": "$text-dark-primary",
+                  "content": "Blog",
+                  "fontFamily": "Inter",
+                  "fontSize": 36,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "frame",
+                  "id": "Vd9xq",
+                  "name": "rssButton",
+                  "fill": "$bg-dark-elevated",
+                  "cornerRadius": 8,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    16
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "5jmYA",
+                      "name": "rssText",
+                      "fill": "$orange-600",
+                      "content": "RSS",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ShP65",
+              "name": "Blog List",
+              "width": "fill_container",
+              "layout": "vertical",
+              "children": [
+                {
+                  "id": "N8UkN",
+                  "type": "ref",
+                  "ref": "HaoZE",
+                  "name": "post1",
+                  "descendants": {
+                    "NAuAh": {
+                      "content": "2024年1月15日"
+                    },
+                    "u2FXW": {
+                      "content": "Astro 5.0 の新機能を試してみた"
+                    },
+                    "1h9ql": {
+                      "content": "Astro 5.0 がリリースされたので、新機能のContent Layerやサーバーアイランドを試してみました。"
+                    }
+                  }
+                },
+                {
+                  "id": "xEPc3",
+                  "type": "ref",
+                  "ref": "HaoZE",
+                  "name": "post2",
+                  "descendants": {
+                    "NAuAh": {
+                      "content": "2024年1月10日"
+                    },
+                    "u2FXW": {
+                      "content": "Tailwind CSS v4 への移行ガイド"
+                    },
+                    "1h9ql": {
+                      "content": "Tailwind CSS v4 の主な変更点と、既存プロジェクトからの移行方法をまとめました。"
+                    }
+                  }
+                },
+                {
+                  "id": "76RnP",
+                  "type": "ref",
+                  "ref": "HaoZE",
+                  "name": "post3",
+                  "descendants": {
+                    "NAuAh": {
+                      "content": "2024年1月5日"
+                    },
+                    "u2FXW": {
+                      "content": "TypeScript 5.3 の satisfies 演算子活用術"
+                    },
+                    "1h9ql": {
+                      "content": "TypeScript 5.3 で追加された satisfies 演算子の実践的な使い方を解説します。"
+                    }
+                  }
+                },
+                {
+                  "id": "1Ke5W",
+                  "type": "ref",
+                  "ref": "HaoZE",
+                  "name": "post4",
+                  "descendants": {
+                    "NAuAh": {
+                      "content": "2023年12月28日"
+                    },
+                    "u2FXW": {
+                      "content": "2023年の振り返りと2024年の目標"
+                    },
+                    "1h9ql": {
+                      "content": "2023年に取り組んだプロジェクトを振り返り、来年の目標を設定しました。"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "sE6DS",
+          "name": "blogFooter",
+          "width": "fill_container",
+          "fill": "$bg-dark-muted",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-dark"
+          },
+          "layout": "vertical",
+          "padding": 32,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "AB1lx",
+              "name": "footerText",
+              "fill": "$text-dark-muted",
+              "content": "© 2024 ta93abe. All rights reserved.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "YLMiF",
+      "x": 4620,
+      "y": 3351,
+      "name": "Links Page - Dark",
+      "width": 1440,
+      "fill": "$bg-dark-primary",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "817S3",
+          "name": "linksHeader",
+          "width": "fill_container",
+          "fill": "$bg-dark-surface",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-dark"
+          },
+          "padding": [
+            16,
+            48
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "id": "GSPHY",
+              "type": "ref",
+              "ref": "v08Ll",
+              "name": "headerLogo"
+            },
+            {
+              "type": "frame",
+              "id": "1PZFh",
+              "name": "Nav Links",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "kta52",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Home",
+                  "name": "navHome"
+                },
+                {
+                  "id": "HSx1k",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Works",
+                  "name": "navWorks"
+                },
+                {
+                  "id": "p8LJr",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Blog",
+                  "name": "navBlog"
+                },
+                {
+                  "id": "LK5aA",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Links",
+                  "name": "navLinks"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "pOhRl",
+          "name": "Links Main",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            48,
+            200
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "ZEo2R",
+              "name": "linksTitle",
+              "fill": "$text-dark-primary",
+              "content": "Links",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "V2rnL",
+              "name": "linksDesc",
+              "fill": "$text-dark-secondary",
+              "content": "SNS・ソーシャルメディアのリンク一覧です。",
+              "fontFamily": "Inter",
+              "fontSize": 16,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "Gl1S6",
+              "name": "Links Grid",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "id": "YzVrX",
+                  "type": "ref",
+                  "ref": "AnbBZ",
+                  "name": "link1",
+                  "descendants": {
+                    "XF505": {
+                      "content": "X"
+                    },
+                    "qXADo": {
+                      "content": "Twitter / X"
+                    },
+                    "m2Xh3": {
+                      "content": "@ta93abe"
+                    }
+                  }
+                },
+                {
+                  "id": "0zFnQ",
+                  "type": "ref",
+                  "ref": "AnbBZ",
+                  "name": "link2",
+                  "descendants": {
+                    "XF505": {
+                      "content": "GH"
+                    },
+                    "qXADo": {
+                      "content": "GitHub"
+                    },
+                    "m2Xh3": {
+                      "content": "github.com/ta93abe"
+                    }
+                  }
+                },
+                {
+                  "id": "g6boa",
+                  "type": "ref",
+                  "ref": "AnbBZ",
+                  "name": "link3",
+                  "descendants": {
+                    "XF505": {
+                      "content": "Z"
+                    },
+                    "qXADo": {
+                      "content": "Zenn"
+                    },
+                    "m2Xh3": {
+                      "content": "zenn.dev/ta93abe"
+                    }
+                  }
+                },
+                {
+                  "id": "B9Zk2",
+                  "type": "ref",
+                  "ref": "AnbBZ",
+                  "name": "link4",
+                  "descendants": {
+                    "XF505": {
+                      "content": "Li"
+                    },
+                    "qXADo": {
+                      "content": "LinkedIn"
+                    },
+                    "m2Xh3": {
+                      "content": "linkedin.com/in/ta93abe"
+                    }
+                  }
+                },
+                {
+                  "id": "f0Go7",
+                  "type": "ref",
+                  "ref": "AnbBZ",
+                  "name": "link5",
+                  "descendants": {
+                    "XF505": {
+                      "content": "SP"
+                    },
+                    "qXADo": {
+                      "content": "Speaker Deck"
+                    },
+                    "m2Xh3": {
+                      "content": "speakerdeck.com/ta93abe"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ct0tf",
+          "name": "linksFooter",
+          "width": "fill_container",
+          "fill": "$bg-dark-muted",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-dark"
+          },
+          "layout": "vertical",
+          "padding": 32,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "oqwdy",
+              "name": "footerText",
+              "fill": "$text-dark-muted",
+              "content": "© 2024 ta93abe. All rights reserved.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "xyPHE",
+      "x": 6160,
+      "y": 3351,
+      "name": "404 Page - Dark",
+      "width": 1440,
+      "height": 900,
+      "fill": "$bg-dark-primary",
+      "justifyContent": "center",
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "frame",
+          "id": "wSLGo",
+          "name": "Error Content",
+          "layout": "vertical",
+          "gap": 32,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "5Paqc",
+              "name": "error404",
+              "fill": "$violet-400",
+              "content": "404",
+              "fontFamily": "Inter",
+              "fontSize": 144,
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "qkuEe",
+              "name": "errorTitle",
+              "fill": "$text-dark-primary",
+              "content": "ページが見つかりません",
+              "fontFamily": "Inter",
+              "fontSize": 32,
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "ribf8",
+              "name": "errorDesc",
+              "fill": "$text-dark-secondary",
+              "content": "お探しのページは存在しないか、移動または削除された可能性があります。",
+              "textAlign": "center",
+              "fontFamily": "Inter",
+              "fontSize": 16,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "9h2I7",
+              "name": "Error Buttons",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "jKje9",
+                  "name": "homeBtn",
+                  "fill": "$violet-500",
+                  "cornerRadius": 8,
+                  "padding": [
+                    12,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "LfgWx",
+                      "name": "homeBtnText",
+                      "fill": "#ffffff",
+                      "content": "ホームに戻る",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "wDSgb",
+                  "name": "backBtn",
+                  "fill": "transparent",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "thickness": 2,
+                    "fill": "$border-dark"
+                  },
+                  "padding": [
+                    12,
+                    24
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tUcit",
+                      "name": "backBtnText",
+                      "fill": "$text-secondary",
+                      "content": "前のページへ",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "757RH",
+              "name": "errorIcon",
+              "opacity": 0.2,
+              "content": "🔍",
+              "fontFamily": "Inter",
+              "fontSize": 64,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "nkcfu",
+      "x": 7700,
+      "y": 961,
+      "name": "Tools Page - Dark",
+      "width": 1440,
+      "fill": "$bg-dark-primary",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "bruBF",
+          "name": "toolsHeader",
+          "width": "fill_container",
+          "fill": "$bg-dark-surface",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-dark"
+          },
+          "padding": [
+            16,
+            48
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "id": "BybdZ",
+              "type": "ref",
+              "ref": "v08Ll",
+              "name": "headerLogo"
+            },
+            {
+              "type": "frame",
+              "id": "mmz16",
+              "name": "Nav Links",
+              "gap": 32,
+              "alignItems": "center",
+              "children": [
+                {
+                  "id": "RGp0d",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Home",
+                  "name": "navHome"
+                },
+                {
+                  "id": "vf4M4",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Works",
+                  "name": "navWorks"
+                },
+                {
+                  "id": "hmi6c",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Blog",
+                  "name": "navBlog"
+                },
+                {
+                  "id": "CCPpw",
+                  "type": "ref",
+                  "ref": "FJk13",
+                  "content": "Links",
+                  "name": "navLinks"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "jFYbh",
+          "name": "Tools Main",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 32,
+          "padding": [
+            48,
+            96
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "FkEos",
+              "name": "toolsTitle",
+              "fill": "$text-dark-primary",
+              "content": "Tools",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "mh8oT",
+              "name": "toolsDesc",
+              "fill": "$text-dark-secondary",
+              "content": "普段の開発で使用しているCLIツールやアプリケーションの一覧です。",
+              "fontFamily": "Inter",
+              "fontSize": 16,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "i2t7L",
+              "name": "Stats Row",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "OQEFF",
+                  "name": "stat1",
+                  "width": 200,
+                  "fill": "$bg-dark-muted",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "$border-dark"
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 24,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "95Tqv",
+                      "name": "stat1Num",
+                      "fill": "$blue-600",
+                      "content": "150+",
+                      "fontFamily": "Inter",
+                      "fontSize": 32,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Rafsg",
+                      "name": "stat1Label",
+                      "fill": "$text-secondary",
+                      "content": "ツール総数",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "1mV0U",
+                  "name": "stat2",
+                  "width": 200,
+                  "fill": "$bg-dark-muted",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "$border-dark"
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 24,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ZIVju",
+                      "name": "stat2Num",
+                      "fill": "$green-600",
+                      "content": "28",
+                      "fontFamily": "Inter",
+                      "fontSize": 32,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "1E3Vj",
+                      "name": "stat2Label",
+                      "fill": "$text-secondary",
+                      "content": "カテゴリ数",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ROpwK",
+                  "name": "stat3",
+                  "width": 200,
+                  "fill": "$bg-dark-muted",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "$border-dark"
+                  },
+                  "layout": "vertical",
+                  "gap": 4,
+                  "padding": 24,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rT8ge",
+                      "name": "stat3Num",
+                      "fill": "$purple-600",
+                      "content": "100%",
+                      "fontFamily": "Inter",
+                      "fontSize": 32,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "XTH6F",
+                      "name": "stat3Label",
+                      "fill": "$text-secondary",
+                      "content": "Nix管理率",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Rxn1P",
+              "name": "Category Shell",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "JZBK7",
+                  "name": "cat1Title",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "LUZH6",
+                      "name": "cat1Icon",
+                      "content": "🐚",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "4D4CE",
+                      "name": "cat1Name",
+                      "fill": "$text-primary",
+                      "content": "シェル・ターミナル",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "JcfOx",
+                      "name": "cat1Count",
+                      "fill": "$text-muted",
+                      "content": "(4)",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "9XQ05",
+                  "name": "Tools Grid",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "id": "obHXI",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "tool1",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Fish"
+                        },
+                        "qoMv0": {
+                          "content": "シンタックスハイライトと強力な補完機能を持つモダンなシェル"
+                        },
+                        "axro8": {
+                          "content": "fishshell.com"
+                        }
+                      }
+                    },
+                    {
+                      "id": "Z1Aw7",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "tool2",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Starship"
+                        },
+                        "qoMv0": {
+                          "content": "高速でカスタマイズ可能なクロスシェルプロンプト"
+                        },
+                        "axro8": {
+                          "content": "starship.rs"
+                        }
+                      }
+                    },
+                    {
+                      "id": "QLP9P",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "tool3",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Ghostty"
+                        },
+                        "qoMv0": {
+                          "content": "高速でGPUアクセラレーション対応のターミナルエミュレータ"
+                        },
+                        "axro8": {
+                          "content": "ghostty.org"
+                        }
+                      }
+                    },
+                    {
+                      "id": "Dnqak",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "tool4",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Zellij"
+                        },
+                        "qoMv0": {
+                          "content": "Vim風キーバインドを持つターミナルマルチプレクサ"
+                        },
+                        "axro8": {
+                          "content": "zellij.dev"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Ug4IH",
+              "name": "Category IDE",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "EL8vK",
+                  "name": "cat2Title",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "zVmkx",
+                      "name": "cat2Icon",
+                      "content": "💻",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "rs82u",
+                      "name": "cat2Name",
+                      "fill": "$text-primary",
+                      "content": "IDE・エディタ",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Ub0PG",
+                      "name": "cat2Count",
+                      "fill": "$text-muted",
+                      "content": "(4)",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "d69uJ",
+                  "name": "IDE Grid",
+                  "gap": 16,
+                  "children": [
+                    {
+                      "id": "BvhHl",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "ide1",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "VS Code"
+                        },
+                        "qoMv0": {
+                          "content": "マイクロソフトの強力なコードエディタ"
+                        },
+                        "axro8": {
+                          "content": "code.visualstudio.com"
+                        }
+                      }
+                    },
+                    {
+                      "id": "yl76c",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "ide2",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Cursor"
+                        },
+                        "qoMv0": {
+                          "content": "AI統合型のコードエディタ"
+                        },
+                        "axro8": {
+                          "content": "cursor.sh"
+                        }
+                      }
+                    },
+                    {
+                      "id": "MoYoh",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "ide3",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Zed"
+                        },
+                        "qoMv0": {
+                          "content": "高速で協調作業に最適化されたコードエディタ"
+                        },
+                        "axro8": {
+                          "content": "zed.dev"
+                        }
+                      }
+                    },
+                    {
+                      "id": "TeHdo",
+                      "type": "ref",
+                      "ref": "BndNx",
+                      "name": "ide4",
+                      "descendants": {
+                        "CdHXJ": {
+                          "content": "Helix"
+                        },
+                        "qoMv0": {
+                          "content": "Rustで書かれたポストモダンなモーダルテキストエディタ"
+                        },
+                        "axro8": {
+                          "content": "helix-editor.com"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "p0yA6",
+          "name": "toolsFooter",
+          "width": "fill_container",
+          "fill": "$bg-dark-muted",
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "$border-dark"
+          },
+          "layout": "vertical",
+          "padding": 32,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "CEjfF",
+              "name": "footerText",
+              "fill": "$text-dark-muted",
+              "content": "© 2024 ta93abe. All rights reserved.",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
     }
   ],
   "variables": {
@@ -7480,6 +9289,141 @@
     "text-xs": {
       "type": "number",
       "value": 12
+    },
+    "accent-coral": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#E85A4F"
+        },
+        {
+          "value": "#f43f5e"
+        }
+      ]
+    },
+    "bg-muted": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#F5F4F2"
+        },
+        {
+          "value": "#f5f5f4"
+        }
+      ]
+    },
+    "bg-warm": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FCFBF9"
+        },
+        {
+          "value": "#fafaf9"
+        }
+      ]
+    },
+    "bg-warm-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#FFF5F3"
+        },
+        {
+          "value": "#fff1f2"
+        }
+      ]
+    },
+    "border-subtle": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#EFEFEF"
+        },
+        {
+          "value": "#e7e5e4"
+        }
+      ]
+    },
+    "text-dark": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#1E2432"
+        },
+        {
+          "value": "#1c1917"
+        }
+      ]
+    },
+    "text-light": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#ABABAB"
+        },
+        {
+          "value": "#a8a29e"
+        }
+      ]
+    },
+    "text-mid": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#8A8A8A"
+        },
+        {
+          "value": "#78716c"
+        }
+      ]
+    },
+    "accent-dark-coral": {
+      "type": "color",
+      "value": "#fb7185"
+    },
+    "bg-dark-elevated": {
+      "type": "color",
+      "value": "#3f3f46"
+    },
+    "bg-dark-muted": {
+      "type": "color",
+      "value": "#27272a"
+    },
+    "bg-dark-primary": {
+      "type": "color",
+      "value": "#0a0a0a"
+    },
+    "bg-dark-surface": {
+      "type": "color",
+      "value": "#18181b"
+    },
+    "border-dark": {
+      "type": "color",
+      "value": "#3f3f46"
+    },
+    "border-dark-subtle": {
+      "type": "color",
+      "value": "#27272a"
+    },
+    "text-dark-muted": {
+      "type": "color",
+      "value": [
+        {
+          "value": "#71717a"
+        },
+        {
+          "value": "#9898a0"
+        }
+      ]
+    },
+    "text-dark-primary": {
+      "type": "color",
+      "value": "#fafafa"
+    },
+    "text-dark-secondary": {
+      "type": "color",
+      "value": "#a1a1aa"
     }
   }
 }


### PR DESCRIPTION
feat: add initial design file created with Pencil

feat(design): add dark mode design system and page variants

Add comprehensive dark mode support to the design file including:
- Dark mode color variables (bg-dark-primary, text-dark-primary, etc.)
- Dark mode variants for all pages (Landing, Works, Blog, Links, 404, Tools)
- Dark mode component variants (Button, NavLink, Logo, WorkCard, BlogPostItem, SnsLinkItem, ToolCard)
- Accessibility fix: update text-dark-muted color for WCAG AA compliance (contrast ratio 6.1:1)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>