### PR TITLE
feat(web3): add ENS profile card with 3D interaction

### DIFF
--- a/docs/plans/2026-02-16-ens-profile-design.md
+++ b/docs/plans/2026-02-16-ens-profile-design.md
@@ -1,0 +1,80 @@
+# ENS Profile Display Design
+
+Linear Issue: TA-351
+
+## Goal
+
+`ta93abe.eth` のENSプロフィール情報をビルド時に取得し、トップページのAboutセクションに3Dインタラクティブカードとして表示する。
+
+## Architecture
+
+```
+[Astro Build Time]
+  └─ src/utils/ens.ts (viem)
+       └─ Cloudflare Ethereum Gateway (cloudflare-eth.com)
+            └─ ENS Registry → Resolver → Profile Data
+
+[Output: Static HTML + Client JS for 3D interaction]
+```
+
+## Data Flow
+
+1. ビルド時に `src/utils/ens.ts` が viem で `ta93abe.eth` のプロフィールを取得
+2. `AboutSection.astro` が `ens.ts` をインポートしてデータ取得
+3. `EnsProfileCard.astro` がカード形式でレンダリング
+4. クライアントJSがマウス/ジャイロ追従の3D回転を処理
+5. 出力は静的HTML — ランタイムでのEthereum呼び出しなし
+
+## ENS Records to Fetch
+
+| Record | Key | Usage |
+|--------|-----|-------|
+| Avatar | avatar | カードのアバター画像 |
+| Description | description | プロフィール説明文 |
+| Twitter | com.twitter | SNSリンク |
+| GitHub | com.github | SNSリンク |
+| URL | url | ウェブサイトリンク |
+| Address | (resolved) | ウォレットアドレス表示 |
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `src/utils/ens.ts` | viem でENSプロフィール取得 |
+| `src/components/landing/EnsProfileCard.astro` | 3Dカードコンポーネント |
+| `src/__tests__/utils/ens.test.ts` | ENSユーティリティのテスト |
+
+## Modified Files
+
+| File | Change |
+|------|--------|
+| `src/components/landing/AboutSection.astro` | EnsProfileCard を追加 |
+| `src/config/site.ts` | `ensName` 設定を追加 |
+| `package.json` | viem を依存に追加 |
+
+## 3D Card Interaction
+
+- CSS `perspective(1000px)` + `transform-style: preserve-3d`
+- マウス位置に応じて `rotateX` / `rotateY` を計算
+- ホログラフィック光沢グラデーション（マウス追従）
+- モバイル: `DeviceOrientationEvent` でジャイロ追従
+- `prefers-reduced-motion` 対応: アニメーション無効時はフラット表示
+
+## Error Handling
+
+- ENS解決失敗時 → カードを非表示（グレースフルデグレード）
+- アバター未設定 → デフォルトアイコン表示
+- 各テキストレコード未設定 → その項目をスキップ
+
+## Dependencies
+
+- `viem`: Ethereum interaction (ENS resolution at build time only)
+
+## Approach Decision
+
+viem を採用。理由:
+- Tree-shakeable で軽量
+- TypeScript-first
+- ENS専用API (`getEnsAvatar`, `getEnsText`, `getEnsAddress`) あり
+- Cloudflare Ethereum Gateway をトランスポートに直接使用可能
+- ビルド時のみ実行のため、バンドルサイズに影響なし

--- a/docs/plans/2026-02-16-ens-profile-plan.md
+++ b/docs/plans/2026-02-16-ens-profile-plan.md
@@ -1,0 +1,359 @@
+# ENS Profile Display Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** `ta93abe.eth` のENSプロフィールをビルド時に取得し、Aboutセクションに3Dインタラクティブカードとして表示する。
+
+**Architecture:** Astroビルド時にviemを使ってCloudflare Ethereum Gateway経由でENSプロフィールを取得。静的HTMLとして出力し、クライアントサイドJSでCSS 3D回転とホログラフィック光沢エフェクトを適用。
+
+**Tech Stack:** viem, Astro, CSS 3D transforms, Cloudflare Ethereum Gateway
+
+**Design Doc:** `docs/plans/2026-02-16-ens-profile-design.md`
+
+---
+
+### Task 1: Install viem and add ENS config
+
+**Files:**
+- Modify: `package.json` (add viem dependency)
+- Modify: `src/config/site.ts` (add ensName)
+
+**Step 1: Install viem**
+
+Run: `pnpm add viem`
+
+**Step 2: Add ENS name to site config**
+
+In `src/config/site.ts`, add `ensName` to the SITE object:
+
+```ts
+export const SITE = {
+	name: "Portfolio",
+	description: "個人ポートフォリオサイト",
+	author: "Takumi Abe",
+	url: "https://ta93abe.com",
+	slidesUrl: "https://slides.ta93abe.com",
+	locale: "ja_JP",
+	lang: "ja",
+	ensName: "ta93abe.eth",
+} as const;
+```
+
+**Step 3: Commit**
+
+```bash
+gt create -m "feat(web3): add viem and ENS config"
+```
+
+---
+
+### Task 2: Create ENS utility with tests (TDD)
+
+**Files:**
+- Create: `src/utils/ens.ts`
+- Create: `src/__tests__/utils/ens.test.ts`
+
+**Step 1: Write the failing test**
+
+Create `src/__tests__/utils/ens.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+
+// Mock viem before importing
+vi.mock("viem", () => ({
+	createPublicClient: vi.fn(() => ({
+		getEnsAddress: vi.fn(),
+		getEnsAvatar: vi.fn(),
+		getEnsText: vi.fn(),
+	})),
+	http: vi.fn(),
+}));
+
+vi.mock("viem/chains", () => ({
+	mainnet: { id: 1, name: "mainnet" },
+}));
+
+import { getEnsProfile } from "../../utils/ens";
+
+describe("getEnsProfile", () => {
+	it("should return null when ENS resolution fails", async () => {
+		const { createPublicClient } = await import("viem");
+		const mockClient = {
+			getEnsAddress: vi.fn().mockResolvedValue(null),
+			getEnsAvatar: vi.fn().mockResolvedValue(null),
+			getEnsText: vi.fn().mockResolvedValue(null),
+		};
+		vi.mocked(createPublicClient).mockReturnValue(mockClient as any);
+
+		const result = await getEnsProfile("nonexistent.eth");
+		expect(result).toBeNull();
+	});
+
+	it("should return profile data when ENS resolves", async () => {
+		const { createPublicClient } = await import("viem");
+		const mockClient = {
+			getEnsAddress: vi.fn().mockResolvedValue("0x1234567890abcdef1234567890abcdef12345678"),
+			getEnsAvatar: vi.fn().mockResolvedValue("https://example.com/avatar.png"),
+			getEnsText: vi.fn().mockImplementation(({ key }: { key: string }) => {
+				const records: Record<string, string> = {
+					description: "Software Engineer",
+					"com.twitter": "ta93abe",
+					"com.github": "ta93abe",
+					url: "https://ta93abe.com",
+				};
+				return Promise.resolve(records[key] ?? null);
+			}),
+		};
+		vi.mocked(createPublicClient).mockReturnValue(mockClient as any);
+
+		const result = await getEnsProfile("ta93abe.eth");
+
+		expect(result).not.toBeNull();
+		expect(result!.ensName).toBe("ta93abe.eth");
+		expect(result!.address).toBe("0x1234567890abcdef1234567890abcdef12345678");
+		expect(result!.avatar).toBe("https://example.com/avatar.png");
+		expect(result!.description).toBe("Software Engineer");
+		expect(result!.twitter).toBe("ta93abe");
+		expect(result!.github).toBe("ta93abe");
+		expect(result!.url).toBe("https://ta93abe.com");
+	});
+
+	it("should handle partial records gracefully", async () => {
+		const { createPublicClient } = await import("viem");
+		const mockClient = {
+			getEnsAddress: vi.fn().mockResolvedValue("0xabcdef"),
+			getEnsAvatar: vi.fn().mockResolvedValue(null),
+			getEnsText: vi.fn().mockResolvedValue(null),
+		};
+		vi.mocked(createPublicClient).mockReturnValue(mockClient as any);
+
+		const result = await getEnsProfile("ta93abe.eth");
+
+		expect(result).not.toBeNull();
+		expect(result!.address).toBe("0xabcdef");
+		expect(result!.avatar).toBeNull();
+		expect(result!.description).toBeNull();
+	});
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run src/__tests__/utils/ens.test.ts`
+Expected: FAIL with "Cannot find module '../../utils/ens'"
+
+**Step 3: Write minimal implementation**
+
+Create `src/utils/ens.ts`:
+
+```ts
+import { createPublicClient, http } from "viem";
+import { mainnet } from "viem/chains";
+
+export interface EnsProfile {
+	ensName: string;
+	address: string;
+	avatar: string | null;
+	description: string | null;
+	twitter: string | null;
+	github: string | null;
+	url: string | null;
+}
+
+const client = createPublicClient({
+	chain: mainnet,
+	transport: http("https://cloudflare-eth.com"),
+});
+
+export async function getEnsProfile(
+	ensName: string,
+): Promise<EnsProfile | null> {
+	try {
+		const address = await client.getEnsAddress({ name: ensName });
+		if (!address) return null;
+
+		const [avatar, description, twitter, github, url] = await Promise.all([
+			client.getEnsAvatar({ name: ensName }),
+			client.getEnsText({ name: ensName, key: "description" }),
+			client.getEnsText({ name: ensName, key: "com.twitter" }),
+			client.getEnsText({ name: ensName, key: "com.github" }),
+			client.getEnsText({ name: ensName, key: "url" }),
+		]);
+
+		return {
+			ensName,
+			address,
+			avatar,
+			description,
+			twitter,
+			github,
+			url,
+		};
+	} catch {
+		return null;
+	}
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run src/__tests__/utils/ens.test.ts`
+Expected: PASS (3 tests)
+
+**Step 5: Run linting**
+
+Run: `pnpm assist`
+
+**Step 6: Commit**
+
+```bash
+gt create -m "feat(web3): add ENS profile utility with tests"
+```
+
+---
+
+### Task 3: Create 3D ENS Profile Card component
+
+**Files:**
+- Create: `src/components/landing/EnsProfileCard.astro`
+
+**Step 1: Create the component**
+
+Create `src/components/landing/EnsProfileCard.astro` with:
+
+1. **Props**: ENS profile data (ensName, address, avatar, description, twitter, github, url)
+2. **HTML**: Card structure with avatar, name, address, description, social links
+3. **CSS**: 3D perspective, holographic gradient, glassmorphism
+4. **Client JS** (`<script>` tag):
+   - Mouse tracking: calculate `rotateX`/`rotateY` from mouse position relative to card center
+   - Holographic overlay: gradient position follows mouse
+   - Mobile: `DeviceOrientationEvent` for gyro-based tilt
+   - `prefers-reduced-motion`: disable all transforms, show flat card
+   - Address truncation: `0x1234...abcd` format
+
+Key CSS properties:
+```css
+.ens-card-wrapper {
+  perspective: 1000px;
+}
+.ens-card {
+  transform-style: preserve-3d;
+  transition: transform 0.1s ease-out;
+}
+.ens-card-shine {
+  /* holographic gradient overlay */
+  background: linear-gradient(
+    105deg,
+    transparent 40%,
+    rgba(255, 219, 112, 0.2) 45%,
+    rgba(132, 50, 255, 0.1) 50%,
+    transparent 54%
+  );
+}
+```
+
+**Step 2: Verify with dev server**
+
+Run: `pnpm dev`
+Manually check that the component renders correctly at localhost:4321 (will integrate in next task)
+
+**Step 3: Commit**
+
+```bash
+gt create -m "feat(web3): add 3D ENS profile card component"
+```
+
+---
+
+### Task 4: Integrate into AboutSection
+
+**Files:**
+- Modify: `src/components/landing/AboutSection.astro`
+
+**Step 1: Import and use EnsProfileCard**
+
+In the frontmatter of `AboutSection.astro`, import the ENS utility and component:
+
+```astro
+---
+import { SITE } from "../../config/site";
+import { getEnsProfile } from "../../utils/ens";
+import EnsProfileCard from "./EnsProfileCard.astro";
+
+const ensProfile = await getEnsProfile(SITE.ensName);
+---
+```
+
+Add the card after the existing `about-content` div, inside `about-container`:
+
+```astro
+{ensProfile && (
+  <div class="ens-section" data-animate="fade-up">
+    <EnsProfileCard profile={ensProfile} />
+  </div>
+)}
+```
+
+Add CSS for `.ens-section`:
+```css
+.ens-section {
+  margin-top: 4rem;
+  display: flex;
+  justify-content: center;
+}
+```
+
+**Step 2: Test with dev server**
+
+Run: `pnpm dev`
+Open http://localhost:4321 and scroll to About section.
+Expected: ENS profile card appears below the stats with 3D tilt effect.
+
+**Step 3: Test build**
+
+Run: `pnpm build`
+Expected: Build completes. ENS data fetched at build time and baked into static HTML.
+
+**Step 4: Run all tests**
+
+Run: `pnpm test:run`
+Expected: All tests pass.
+
+**Step 5: Run linting**
+
+Run: `pnpm assist`
+
+**Step 6: Commit**
+
+```bash
+gt create -m "feat(web3): integrate ENS profile card into About section"
+```
+
+---
+
+### Task 5: Final verification and PR
+
+**Step 1: Full build verification**
+
+Run: `pnpm build && pnpm preview`
+Open http://localhost:4321 and verify:
+- [ ] ENS card appears in About section
+- [ ] 3D tilt works on mouse move
+- [ ] Holographic shine effect works
+- [ ] Address is truncated (0x1234...abcd)
+- [ ] Social links are clickable
+- [ ] Mobile responsive
+- [ ] prefers-reduced-motion works (disable animations in OS settings)
+
+**Step 2: All tests pass**
+
+Run: `pnpm test:run && pnpm assist`
+
+**Step 3: Submit PR**
+
+Run: `gt submit --no-interactive`
+
+**Step 4: Update Linear issue**
+
+Move TA-351 to "In Review" status.

--- a/src/__tests__/utils/ens.test.ts
+++ b/src/__tests__/utils/ens.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock viem before importing
+vi.mock("viem", () => ({
+	createPublicClient: vi.fn(() => ({
+		getEnsAddress: vi.fn(),
+		getEnsAvatar: vi.fn(),
+		getEnsText: vi.fn(),
+	})),
+	http: vi.fn(),
+}));
+
+vi.mock("viem/chains", () => ({
+	mainnet: { id: 1, name: "mainnet" },
+}));
+
+import { getEnsProfile } from "../../utils/ens";
+
+describe("getEnsProfile", () => {
+	it("should return null when ENS resolution fails", async () => {
+		const { createPublicClient } = await import("viem");
+		const mockClient = {
+			getEnsAddress: vi.fn().mockResolvedValue(null),
+			getEnsAvatar: vi.fn().mockResolvedValue(null),
+			getEnsText: vi.fn().mockResolvedValue(null),
+		};
+		vi.mocked(createPublicClient).mockReturnValue(
+			mockClient as unknown as ReturnType<typeof createPublicClient>,
+		);
+
+		const result = await getEnsProfile("nonexistent.eth");
+		expect(result).toBeNull();
+	});
+
+	it("should return profile data when ENS resolves", async () => {
+		const { createPublicClient } = await import("viem");
+		const mockClient = {
+			getEnsAddress: vi
+				.fn()
+				.mockResolvedValue("0x1234567890abcdef1234567890abcdef12345678"),
+			getEnsAvatar: vi.fn().mockResolvedValue("https://example.com/avatar.png"),
+			getEnsText: vi.fn().mockImplementation(({ key }: { key: string }) => {
+				const records: Record<string, string> = {
+					description: "Software Engineer",
+					"com.twitter": "ta93abe",
+					"com.github": "ta93abe",
+					url: "https://ta93abe.com",
+				};
+				return Promise.resolve(records[key] ?? null);
+			}),
+		};
+		vi.mocked(createPublicClient).mockReturnValue(
+			mockClient as unknown as ReturnType<typeof createPublicClient>,
+		);
+
+		const result = await getEnsProfile("ta93abe.eth");
+
+		expect(result).not.toBeNull();
+		expect(result?.ensName).toBe("ta93abe.eth");
+		expect(result?.address).toBe("0x1234567890abcdef1234567890abcdef12345678");
+		expect(result?.avatar).toBe("https://example.com/avatar.png");
+		expect(result?.description).toBe("Software Engineer");
+		expect(result?.twitter).toBe("ta93abe");
+		expect(result?.github).toBe("ta93abe");
+		expect(result?.url).toBe("https://ta93abe.com");
+	});
+
+	it("should handle partial records gracefully", async () => {
+		const { createPublicClient } = await import("viem");
+		const mockClient = {
+			getEnsAddress: vi.fn().mockResolvedValue("0xabcdef"),
+			getEnsAvatar: vi.fn().mockResolvedValue(null),
+			getEnsText: vi.fn().mockResolvedValue(null),
+		};
+		vi.mocked(createPublicClient).mockReturnValue(
+			mockClient as unknown as ReturnType<typeof createPublicClient>,
+		);
+
+		const result = await getEnsProfile("ta93abe.eth");
+
+		expect(result).not.toBeNull();
+		expect(result?.address).toBe("0xabcdef");
+		expect(result?.avatar).toBeNull();
+		expect(result?.description).toBeNull();
+	});
+});

--- a/src/components/landing/AboutSection.astro
+++ b/src/components/landing/AboutSection.astro
@@ -1,5 +1,10 @@
 ---
 // Aboutセクション - スクロールアニメーション付き
+import { SITE } from "../../config/site";
+import { getEnsProfile } from "../../utils/ens";
+import EnsProfileCard from "./EnsProfileCard.astro";
+
+const ensProfile = await getEnsProfile(SITE.ensName);
 ---
 
 <section id="about" class="about-section">
@@ -34,6 +39,12 @@
         </div>
       </div>
     </div>
+
+    {ensProfile && (
+      <div class="ens-section" data-animate="fade-up">
+        <EnsProfileCard profile={ensProfile} />
+      </div>
+    )}
   </div>
 </section>
 
@@ -113,6 +124,12 @@
     margin-top: 0.5rem;
     letter-spacing: 0.1em;
     text-transform: uppercase;
+  }
+
+  .ens-section {
+    margin-top: 4rem;
+    display: flex;
+    justify-content: center;
   }
 
   @media (max-width: 768px) {

--- a/src/components/landing/EnsProfileCard.astro
+++ b/src/components/landing/EnsProfileCard.astro
@@ -289,14 +289,17 @@ function truncateAddress(address: string): string {
 
 <script>
   function initEnsCard() {
+    const card = document.querySelector<HTMLElement>("[data-ens-card]");
+    if (!card || card.dataset.ensCardInitialized) return;
+    card.dataset.ensCardInitialized = "true";
+
     const prefersReducedMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     );
     if (prefersReducedMotion.matches) return;
 
-    const card = document.querySelector<HTMLElement>("[data-ens-card]");
     const shine = document.querySelector<HTMLElement>("[data-ens-shine]");
-    if (!card || !shine) return;
+    if (!shine) return;
 
     const MAX_ROTATION = 15;
 
@@ -341,8 +344,6 @@ function truncateAddress(address: string): string {
     function handleOrientation(e: DeviceOrientationEvent) {
       if (e.gamma === null || e.beta === null) return;
 
-      // gamma: left-right tilt (-90 to 90)
-      // beta: front-back tilt (-180 to 180)
       const rotateY = (e.gamma / 90) * MAX_ROTATION;
       const rotateX = Math.max(
         -MAX_ROTATION,
@@ -359,7 +360,6 @@ function truncateAddress(address: string): string {
         typeof DeviceOrientationEvent !== "undefined" &&
         typeof (DeviceOrientationEvent as any).requestPermission === "function"
       ) {
-        // iOS 13+ requires permission
         card.addEventListener(
           "click",
           () => {
@@ -373,9 +373,7 @@ function truncateAddress(address: string): string {
                   );
                 }
               })
-              .catch(() => {
-                // Permission denied - ignore
-              });
+              .catch(() => {});
           },
           { once: true },
         );
@@ -385,17 +383,36 @@ function truncateAddress(address: string): string {
     }
 
     // Listen for reduced motion changes
-    prefersReducedMotion.addEventListener("change", (e) => {
+    const handleReducedMotionChange = (e: MediaQueryListEvent) => {
       if (e.matches) {
         card!.style.transform = "";
         shine!.style.opacity = "0";
-        card.removeEventListener("mousemove", handleMouseMove);
-        card.removeEventListener("mouseleave", handleMouseLeave);
+        card!.removeEventListener("mousemove", handleMouseMove);
+        card!.removeEventListener("mouseleave", handleMouseLeave);
         window.removeEventListener("deviceorientation", handleOrientation);
+        prefersReducedMotion.removeEventListener(
+          "change",
+          handleReducedMotionChange,
+        );
       }
-    });
+    };
+    prefersReducedMotion.addEventListener("change", handleReducedMotionChange);
+
+    // Cleanup on Astro page swap to prevent memory leaks
+    document.addEventListener(
+      "astro:before-swap",
+      () => {
+        card!.removeEventListener("mousemove", handleMouseMove);
+        card!.removeEventListener("mouseleave", handleMouseLeave);
+        window.removeEventListener("deviceorientation", handleOrientation);
+        prefersReducedMotion.removeEventListener(
+          "change",
+          handleReducedMotionChange,
+        );
+      },
+      { once: true },
+    );
   }
 
   document.addEventListener("astro:page-load", initEnsCard);
-  initEnsCard();
 </script>

--- a/src/components/landing/EnsProfileCard.astro
+++ b/src/components/landing/EnsProfileCard.astro
@@ -1,0 +1,401 @@
+---
+// ENS Profile Card - 3Dインタラクティブカード（ホログラフィックシャイン効果付き）
+import type { EnsProfile } from "../../utils/ens";
+
+interface Props {
+	profile: EnsProfile;
+}
+
+const { profile } = Astro.props;
+
+function truncateAddress(address: string): string {
+	if (address.length <= 10) return address;
+	return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+---
+
+<div class="ens-card-wrapper">
+  <div class="ens-card" data-ens-card>
+    <div class="ens-card-shine" data-ens-shine></div>
+    <div class="ens-card-content">
+      <div class="ens-avatar">
+        {
+          profile.avatar ? (
+            <img
+              src={profile.avatar}
+              alt={`${profile.ensName} avatar`}
+              class="ens-avatar-img"
+              width="80"
+              height="80"
+              loading="lazy"
+            />
+          ) : (
+            <div class="ens-avatar-fallback" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2" />
+                <circle cx="12" cy="7" r="4" />
+              </svg>
+            </div>
+          )
+        }
+      </div>
+
+      <h3 class="ens-name">{profile.ensName}</h3>
+
+      <p class="ens-address" title={profile.address}>
+        {truncateAddress(profile.address)}
+      </p>
+
+      {profile.description && (
+        <p class="ens-description">{profile.description}</p>
+      )}
+
+      {(profile.twitter || profile.github || profile.url) && (
+        <div class="ens-socials">
+          {profile.twitter && (
+            <a
+              href={`https://x.com/${profile.twitter}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="ens-social-link"
+              aria-label={`${profile.ensName} on X (Twitter)`}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+              </svg>
+            </a>
+          )}
+
+          {profile.github && (
+            <a
+              href={`https://github.com/${profile.github}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="ens-social-link"
+              aria-label={`${profile.ensName} on GitHub`}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+              </svg>
+            </a>
+          )}
+
+          {profile.url && (
+            <a
+              href={profile.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="ens-social-link"
+              aria-label={`${profile.ensName} website`}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M2 12h20" />
+                <path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z" />
+              </svg>
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  </div>
+</div>
+
+<style>
+  .ens-card-wrapper {
+    perspective: 1000px;
+    width: 100%;
+    max-width: 360px;
+    margin: 0 auto;
+  }
+
+  .ens-card {
+    position: relative;
+    transform-style: preserve-3d;
+    transition: transform 0.1s ease-out;
+    border-radius: 1.25rem;
+    background: #1a1a2e;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow:
+      0 4px 24px rgba(0, 0, 0, 0.12),
+      0 0 0 1px rgba(255, 255, 255, 0.04);
+    overflow: hidden;
+    will-change: transform;
+  }
+
+  .ens-card-shine {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+    border-radius: inherit;
+    background: linear-gradient(
+      105deg,
+      transparent 40%,
+      rgba(255, 219, 112, 0.2) 45%,
+      rgba(132, 50, 255, 0.1) 50%,
+      transparent 54%
+    );
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    mix-blend-mode: screen;
+  }
+
+  .ens-card:hover .ens-card-shine {
+    opacity: 1;
+  }
+
+  .ens-card-content {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2.5rem 2rem 2rem;
+    text-align: center;
+  }
+
+  .ens-avatar {
+    width: 80px;
+    height: 80px;
+    margin-bottom: 1.25rem;
+    flex-shrink: 0;
+  }
+
+  .ens-avatar-img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .ens-avatar-fallback {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.06);
+    border: 2px solid rgba(255, 255, 255, 0.1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .ens-avatar-fallback svg {
+    width: 36px;
+    height: 36px;
+    color: rgba(255, 255, 255, 0.4);
+  }
+
+  .ens-name {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #f0f0f0;
+    margin: 0 0 0.375rem;
+    line-height: 1.2;
+  }
+
+  .ens-address {
+    font-size: 0.8125rem;
+    font-family: "SF Mono", Menlo, Monaco, "Courier New", monospace;
+    color: rgba(255, 255, 255, 0.4);
+    margin: 0 0 1rem;
+    letter-spacing: 0.02em;
+  }
+
+  .ens-description {
+    font-size: 0.9375rem;
+    line-height: 1.6;
+    color: rgba(255, 255, 255, 0.6);
+    margin: 0 0 1.25rem;
+    max-width: 280px;
+  }
+
+  .ens-socials {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: auto;
+  }
+
+  .ens-social-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.5);
+    text-decoration: none;
+    transition:
+      background 0.2s ease,
+      color 0.2s ease,
+      border-color 0.2s ease;
+  }
+
+  .ens-social-link:hover {
+    background: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.9);
+    border-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .ens-social-link svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  @media (max-width: 768px) {
+    .ens-card-wrapper {
+      max-width: 320px;
+    }
+
+    .ens-card-content {
+      padding: 2rem 1.5rem 1.75rem;
+    }
+
+    .ens-name {
+      font-size: 1.25rem;
+    }
+  }
+</style>
+
+<script>
+  function initEnsCard() {
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    );
+    if (prefersReducedMotion.matches) return;
+
+    const card = document.querySelector<HTMLElement>("[data-ens-card]");
+    const shine = document.querySelector<HTMLElement>("[data-ens-shine]");
+    if (!card || !shine) return;
+
+    const MAX_ROTATION = 15;
+
+    function handleMouseMove(e: MouseEvent) {
+      const rect = card!.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+
+      const mouseX = e.clientX - centerX;
+      const mouseY = e.clientY - centerY;
+
+      const rotateY = (mouseX / (rect.width / 2)) * MAX_ROTATION;
+      const rotateX = -(mouseY / (rect.height / 2)) * MAX_ROTATION;
+
+      card!.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
+
+      const shineX = ((e.clientX - rect.left) / rect.width) * 100;
+      const shineY = ((e.clientY - rect.top) / rect.height) * 100;
+      shine!.style.background = `radial-gradient(
+        circle at ${shineX}% ${shineY}%,
+        rgba(255, 219, 112, 0.25) 0%,
+        rgba(132, 50, 255, 0.12) 30%,
+        transparent 60%
+      )`;
+      shine!.style.opacity = "1";
+    }
+
+    function handleMouseLeave() {
+      card!.style.transition = "transform 0.5s ease-out";
+      card!.style.transform = "rotateX(0deg) rotateY(0deg)";
+      shine!.style.opacity = "0";
+
+      setTimeout(() => {
+        card!.style.transition = "transform 0.1s ease-out";
+      }, 500);
+    }
+
+    card.addEventListener("mousemove", handleMouseMove);
+    card.addEventListener("mouseleave", handleMouseLeave);
+
+    // Mobile: DeviceOrientation for gyro-based tilt
+    function handleOrientation(e: DeviceOrientationEvent) {
+      if (e.gamma === null || e.beta === null) return;
+
+      // gamma: left-right tilt (-90 to 90)
+      // beta: front-back tilt (-180 to 180)
+      const rotateY = (e.gamma / 90) * MAX_ROTATION;
+      const rotateX = Math.max(
+        -MAX_ROTATION,
+        Math.min(MAX_ROTATION, ((e.beta - 45) / 45) * MAX_ROTATION),
+      );
+
+      card!.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
+      shine!.style.opacity = "0.6";
+    }
+
+    // Only add gyro on touch devices
+    if ("ontouchstart" in window) {
+      if (
+        typeof DeviceOrientationEvent !== "undefined" &&
+        typeof (DeviceOrientationEvent as any).requestPermission === "function"
+      ) {
+        // iOS 13+ requires permission
+        card.addEventListener(
+          "click",
+          () => {
+            (DeviceOrientationEvent as any)
+              .requestPermission()
+              .then((response: string) => {
+                if (response === "granted") {
+                  window.addEventListener(
+                    "deviceorientation",
+                    handleOrientation,
+                  );
+                }
+              })
+              .catch(() => {
+                // Permission denied - ignore
+              });
+          },
+          { once: true },
+        );
+      } else if (typeof DeviceOrientationEvent !== "undefined") {
+        window.addEventListener("deviceorientation", handleOrientation);
+      }
+    }
+
+    // Listen for reduced motion changes
+    prefersReducedMotion.addEventListener("change", (e) => {
+      if (e.matches) {
+        card!.style.transform = "";
+        shine!.style.opacity = "0";
+        card.removeEventListener("mousemove", handleMouseMove);
+        card.removeEventListener("mouseleave", handleMouseLeave);
+        window.removeEventListener("deviceorientation", handleOrientation);
+      }
+    });
+  }
+
+  document.addEventListener("astro:page-load", initEnsCard);
+  initEnsCard();
+</script>

--- a/src/components/landing/EnsProfileCard.astro
+++ b/src/components/landing/EnsProfileCard.astro
@@ -302,6 +302,8 @@ function truncateAddress(address: string): string {
     if (!shine) return;
 
     const MAX_ROTATION = 15;
+    const NEUTRAL_BETA = 45;
+    const BETA_SENSITIVITY_RANGE = 45;
 
     function handleMouseMove(e: MouseEvent) {
       const rect = card!.getBoundingClientRect();
@@ -347,7 +349,10 @@ function truncateAddress(address: string): string {
       const rotateY = (e.gamma / 90) * MAX_ROTATION;
       const rotateX = Math.max(
         -MAX_ROTATION,
-        Math.min(MAX_ROTATION, ((e.beta - 45) / 45) * MAX_ROTATION),
+        Math.min(
+          MAX_ROTATION,
+          ((e.beta - NEUTRAL_BETA) / BETA_SENSITIVITY_RANGE) * MAX_ROTATION,
+        ),
       );
 
       card!.style.transform = `rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,12 @@
+---
+import AboutSection from "../components/landing/AboutSection.astro";
+import { SITE } from "../config/site";
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout
+	title={`About | ${SITE.name}`}
+	description="ソフトウェアエンジニア ta93abe について。"
+>
+	<AboutSection />
+</Layout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,7 +6,7 @@ import Layout from "../layouts/Layout.astro";
 
 <Layout
 	title={`About | ${SITE.name}`}
-	description="ソフトウェアエンジニア ta93abe について。"
+	description="ソフトウェアエンジニア ta93abe のプロフィール。モダンなWeb技術とWeb3に取り組み、パフォーマンスとアクセシビリティの両立を追求しています。"
 >
 	<AboutSection />
 </Layout>

--- a/src/utils/ens.ts
+++ b/src/utils/ens.ts
@@ -43,7 +43,8 @@ export async function getEnsProfile(
 			github,
 			url,
 		};
-	} catch {
+	} catch (error) {
+		console.error(`[ENS] Failed to fetch profile for ${ensName}:`, error);
 		return null;
 	}
 }

--- a/src/utils/ens.ts
+++ b/src/utils/ens.ts
@@ -1,0 +1,49 @@
+import { createPublicClient, http } from "viem";
+import { mainnet } from "viem/chains";
+
+export interface EnsProfile {
+	ensName: string;
+	address: string;
+	avatar: string | null;
+	description: string | null;
+	twitter: string | null;
+	github: string | null;
+	url: string | null;
+}
+
+function getClient() {
+	return createPublicClient({
+		chain: mainnet,
+		transport: http("https://cloudflare-eth.com"),
+	});
+}
+
+export async function getEnsProfile(
+	ensName: string,
+): Promise<EnsProfile | null> {
+	try {
+		const client = getClient();
+		const address = await client.getEnsAddress({ name: ensName });
+		if (!address) return null;
+
+		const [avatar, description, twitter, github, url] = await Promise.all([
+			client.getEnsAvatar({ name: ensName }),
+			client.getEnsText({ name: ensName, key: "description" }),
+			client.getEnsText({ name: ensName, key: "com.twitter" }),
+			client.getEnsText({ name: ensName, key: "com.github" }),
+			client.getEnsText({ name: ensName, key: "url" }),
+		]);
+
+		return {
+			ensName,
+			address,
+			avatar,
+			description,
+			twitter,
+			github,
+			url,
+		};
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary
- `ta93abe.eth` のENSプロフィールをビルド時にviem経由で取得するユーティリティ追加
- 3Dインタラクティブカード（ホログラフィックシャイン効果、マウス/ジャイロ追従）コンポーネント作成
- AboutSectionへのENSカード統合と `/about` ページ新設
- `prefers-reduced-motion` 対応、メモリリーク対策、エラーログ追加

## Test plan
- [x] `pnpm test:run` でENSユーティリティのユニットテスト通過
- [x] `pnpm build` でビルド時ENSデータ取得成功
- [x] `pnpm assist` でlint/format通過
- [ ] `/about` ページで3Dカード表示確認
- [ ] マウス追従のtilt/shine効果確認
- [ ] レスポンシブ表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * About page now displays an interactive 3D ENS profile card featuring name, avatar, address, description, and linked social profiles.
  * 3D tilt effects respond to mouse movement and device orientation with accessibility support for reduced motion.

* **Tests**
  * Added comprehensive unit tests for ENS profile data retrieval.

* **Chores**
  * Added viem library as a dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->