### PR TITLE
feat: add daily cron trigger to rebuild site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 
 # generated types
 .astro/
+worker-configuration.d.ts
 
 # dependencies
 node_modules/

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -4,9 +4,15 @@ interface Env {
 
 export default {
 	async scheduled(_event, env): Promise<void> {
-		const res = await fetch(env.DEPLOY_HOOK_URL, { method: "POST" });
-		if (!res.ok) {
-			console.error(`deploy hook failed: ${res.status} ${await res.text()}`);
+		try {
+			const res = await fetch(env.DEPLOY_HOOK_URL, { method: "POST" });
+			if (!res.ok) {
+				console.error(
+					`deploy hook failed: ${res.status} ${await res.text()}`,
+				);
+			}
+		} catch (error) {
+			console.error("deploy hook request failed", error);
 		}
 	},
 } satisfies ExportedHandler<Env>;

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,12 @@
+interface Env {
+	DEPLOY_HOOK_URL: string;
+}
+
+export default {
+	async scheduled(_event, env): Promise<void> {
+		const res = await fetch(env.DEPLOY_HOOK_URL, { method: "POST" });
+		if (!res.ok) {
+			console.error(`deploy hook failed: ${res.status} ${await res.text()}`);
+		}
+	},
+} satisfies ExportedHandler<Env>;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,10 +1,14 @@
 {
   "name": "me",
+  "main": "worker/index.ts",
   "compatibility_date": "2026-01-01",
   "assets": {
     "directory": "./dist",
     "html_handling": "auto-trailing-slash",
     "not_found_handling": "404-page",
+  },
+  "triggers": {
+    "crons": ["0 0 * * *"],
   },
   "observability": {
     "enabled": true,


### PR DESCRIPTION
Add a scheduled handler that posts to the Workers Builds deploy hook
once a day so the slides listing (fetched at build time from an external
JSON) stays fresh without manual intervention.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Entire-Checkpoint: 16cc9732715f