### PR TITLE
docs: 全体像の図を Mermaid に書き換え

### DIFF
--- a/docs/sveltia-migration.md
+++ b/docs/sveltia-migration.md
@@ -5,11 +5,21 @@
 
 ## 全体像
 
-```
-┌─ ローカルエディタ ── .md 編集 → git push ─┐
-│                                          ├─→ GitHub (ta93abe/me) ─→ Cloudflare Workers Builds ─→ 自動デプロイ
-└─ Sveltia CMS (GUI) ─ テキスト → commit ──┘
-                       └ 画像 → R2 バケットへ直接アップロード（公開 URL を Markdown に記録）
+```mermaid
+flowchart LR
+	local["ローカルエディタ"]
+	cms["Sveltia CMS（GUI）<br>/admin/"]
+	github["GitHub<br>ta93abe/me"]
+	builds["Cloudflare<br>Workers Builds"]
+	site["ta93abe.com<br>（自動デプロイ）"]
+	r2[("R2: me-images<br>images.ta93abe.com")]
+
+	local -- ".md 編集 → git push" --> github
+	cms -- "テキスト → commit" --> github
+	cms -- "画像を直接アップロード<br>（公開 URL を Markdown に記録）" --> r2
+	github -- "main への push" --> builds
+	builds --> site
+	r2 -. "画像配信" .-> site
 ```
 
 - **真のソースは Git**。GUI で書いてもローカルで書いても、同じ `src/content/**/*.md` に収束する


### PR DESCRIPTION
ASCII アートは GitHub 上で崩れやすいため、レンダリングされる
Mermaid フローチャートに置き換える。

Entire-Checkpoint: bbac766538e5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the migration overview’s ASCII diagram with a Mermaid flowchart.
  * Clarified the workflow between the local editor, CMS, GitHub, automated deployment, and image delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->