### PR TITLE
fix: alchemy を beta.63 に更新して effect beta.97 との不整合を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
 		"@vitest/ui": "^4.1.10",
-		"alchemy": "2.0.0-beta.61",
+		"alchemy": "2.0.0-beta.63",
 		"effect": "4.0.0-beta.97",
 		"happy-dom": "^20.10.6",
 		"oxfmt": "^0.58.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
       alchemy:
-        specifier: 2.0.0-beta.61
-        version: 2.0.0-beta.61(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(@types/node@25.9.5)(@types/react@19.2.17)(effect@4.0.0-beta.97)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.1.10)(workerd@1.20260708.1)(ws@8.21.0)
+        specifier: 2.0.0-beta.63
+        version: 2.0.0-beta.63(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(@types/node@25.9.5)(@types/react@19.2.17)(effect@4.0.0-beta.97)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.1.10)(workerd@1.20260708.1)(ws@8.21.0)
       effect:
         specifier: 4.0.0-beta.97
         version: 4.0.0-beta.97
@@ -463,18 +463,18 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@distilled.cloud/aws@0.28.2':
-    resolution: {integrity: sha512-y7EQmQyTv+6Rt5GYACr8EItXkVtoJ+wTje0F9026XNKmidhNmW13YVTcNTQWOROogj7kKh0FU70jJd6MHuf2HQ==}
+  '@distilled.cloud/aws@0.29.1':
+    resolution: {integrity: sha512-PyckEEQny1QyuLQwHnTprtirUysGKfdYIBn2hi7K7ZEHQ0DaPgOb5Snj7Jg1peRREKZmJ6GIKC7zBKogZQUVxA==}
     peerDependencies:
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
+      effect: '>=4.0.0-beta.97 || >=4.0.0'
 
-  '@distilled.cloud/axiom@0.28.2':
-    resolution: {integrity: sha512-kPPNf8q62kxWvOOIExEGFDADZrAc7T0F+qAlNBPAUw2esmR+qO1hHWaam7ynrI/TpPTZ9aTm6CkfwRnRBxsOeg==}
+  '@distilled.cloud/axiom@0.29.1':
+    resolution: {integrity: sha512-DaEJPLuEwHhDtkpMSsc5zWoGHDxa6/1dJ5a+1kgTNf2Iuzh4dz5zK8cTvTG4ymMQcqpcwxMbcoaGessBwFJxgg==}
     peerDependencies:
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
+      effect: '>=4.0.0-beta.97 || >=4.0.0'
 
-  '@distilled.cloud/cloudflare-rolldown-plugin@0.12.2':
-    resolution: {integrity: sha512-EB061OwpRrBFYmOV6YelfgoFuLCiycSfozzswvb33VFmmvXAXM/7OLSZ0qzNsbU2NE4XQQ5lWA/X60ChJWwKfQ==}
+  '@distilled.cloud/cloudflare-rolldown-plugin@0.13.5':
+    resolution: {integrity: sha512-Yjfv9ZSAmRVGFjHER6IS3eB3xR+U93g621wDImW/KfMtV/quhmisag2xhWi34ermX/EPo5loHdNPROlzzRLDlw==}
     peerDependencies:
       rolldown: ^1.0.1
       vite: ^7.0.0 || ^8.0.0
@@ -484,27 +484,27 @@ packages:
       vite:
         optional: true
 
-  '@distilled.cloud/cloudflare-runtime@0.12.2':
-    resolution: {integrity: sha512-udwB3BREY0OsyFwtUR4Ia2Q+cT63pOEWQtM+Op22mTpfDKFJRcMaomHMwu9VTj4uQuIRqZJe6//KXnOOMEK+Kw==}
+  '@distilled.cloud/cloudflare-runtime@0.13.5':
+    resolution: {integrity: sha512-+Bk8VG0qTVMQmfmHPnoWLsdYGj39x3inbQ8NqFe6vZ5HqMWhYf/F9rrhqz4zECLvAgisx9SBuoveGCZCbALVHA==}
     peerDependencies:
-      '@distilled.cloud/cloudflare': ^0.28.1
-      '@effect/platform-bun': '>=4.0.0-beta.78 || >=4.0.0'
-      '@effect/platform-node': '>=4.0.0-beta.78 || >=4.0.0'
-      effect: '>=4.0.0-beta.78 || >=4.0.0'
+      '@distilled.cloud/cloudflare': ^0.29.0
+      '@effect/platform-bun': '>=4.0.0-beta.97 || >=4.0.0'
+      '@effect/platform-node': '>=4.0.0-beta.97 || >=4.0.0'
+      effect: '>=4.0.0-beta.97 || >=4.0.0'
     peerDependenciesMeta:
       '@effect/platform-bun':
         optional: true
       '@effect/platform-node':
         optional: true
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.12.2':
-    resolution: {integrity: sha512-tHMs5LO+O6MI6YCcVV53mIVL+k4Id1M3hqJZod0mFnYxdumQ/EsAKrGnxtSIgeMI9JJzFhl0qkrW7TZWs3HzJg==}
+  '@distilled.cloud/cloudflare-vite-plugin@0.13.5':
+    resolution: {integrity: sha512-d2UJTIffnq+0+cm0t0PpSgvB/JFSGdSBqDHiTUgZULe+rW9sWRpxZ3ZA50AViZc20yO8idelQ8ANeJr2cTng+w==}
     peerDependencies:
-      '@distilled.cloud/cloudflare': ^0.28.1
-      '@distilled.cloud/cloudflare-runtime': 0.12.2
-      '@effect/platform-bun': '>=4.0.0-beta.78 || >=4.0.0'
-      '@effect/platform-node': '>=4.0.0-beta.78 || >=4.0.0'
-      effect: '>=4.0.0-beta.78 || >=4.0.0'
+      '@distilled.cloud/cloudflare': ^0.29.0
+      '@distilled.cloud/cloudflare-runtime': 0.13.5
+      '@effect/platform-bun': '>=4.0.0-beta.97 || >=4.0.0'
+      '@effect/platform-node': '>=4.0.0-beta.97 || >=4.0.0'
+      effect: '>=4.0.0-beta.97 || >=4.0.0'
       vite: ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@effect/platform-bun':
@@ -512,25 +512,25 @@ packages:
       '@effect/platform-node':
         optional: true
 
-  '@distilled.cloud/cloudflare@0.28.2':
-    resolution: {integrity: sha512-iXnP7VQyEfyXpd3Xx8hZJyn2nv+vonK71TlyrKgeafpggFVztP2w7NWH04sBo036Owi1q8U4kkMBBTptaKN4aw==}
+  '@distilled.cloud/cloudflare@0.29.1':
+    resolution: {integrity: sha512-p450G08Dav7WCOeiguFQbzkUJCJG4kXwwJuujuelggOAMag+wnygWlWNWfeGMmasYvaQlttnMdFhjWa5fDOsyA==}
     peerDependencies:
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
+      effect: '>=4.0.0-beta.97 || >=4.0.0'
 
-  '@distilled.cloud/core@0.28.2':
-    resolution: {integrity: sha512-Ym2MUTRlGCTxndGPc2fU621dU8DsfSJuALRfSP+3bhFxs0AO1fuFaeEpHWfOyOKC9w0NT0NDTUgG9nnlUpLxFA==}
+  '@distilled.cloud/core@0.29.1':
+    resolution: {integrity: sha512-iEsRbvrmpjwqfHy1Bpkwdnoa7OIyoTFUwD4Cg6h7IRDUolvb2RJQUnrV6LDCV9DPJyZcjN5Vnd5zPagPfqz8dg==}
     peerDependencies:
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
+      effect: '>=4.0.0-beta.97 || >=4.0.0'
 
-  '@distilled.cloud/neon@0.28.2':
-    resolution: {integrity: sha512-0g/Zr4ejRG9F0yBS+KWGIPadUCXl+9XBJxnxfHRmoX41/b/fLWiXD0OXfEIoEyaO4THK8ECGgU5PuDHu2NmTag==}
+  '@distilled.cloud/neon@0.29.1':
+    resolution: {integrity: sha512-6vfCvTEZBIfKCDZ+4B4GfuZoGigfBaxnEF21si89Lm7ffCCny2Da/OEhGqwLUvd/WVfMfDOKdvrHuN58O928hw==}
     peerDependencies:
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
+      effect: '>=4.0.0-beta.97 || >=4.0.0'
 
-  '@distilled.cloud/planetscale@0.28.2':
-    resolution: {integrity: sha512-yw3E+zB5Dg7gaNObtzKY/MDuHj8y5x5TlMCK0gUGEyT/30dVCHFFXpY+9MFYhVIO9gQOVIr5qT1gljW6Ag6LXA==}
+  '@distilled.cloud/planetscale@0.29.1':
+    resolution: {integrity: sha512-m/e7V6iyjI24Myr2dVJuTjNqG8JOjyaDEuWeJ/HF8BKAhELHSBAwo2XFQurRjJmB+hzTRoCuasX76NPSXoDcCA==}
     peerDependencies:
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
+      effect: '>=4.0.0-beta.97 || >=4.0.0'
 
   '@effect/platform-node-shared@4.0.0-beta.98':
     resolution: {integrity: sha512-iySXaffnCJX1sNAIp79ghhIeui9E5qwUQyqd1VLPkB9UNO4vdpd9B5fTEXwe7S/GusL4jsk9vSvX38XJgRFG1w==}
@@ -2415,16 +2415,16 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  alchemy@2.0.0-beta.61:
-    resolution: {integrity: sha512-Ij067naUxeovHeqC9Z/tIVS3c73kAEMCcX7hUPzbxL42+5YUoEvC73IxpCcyGT8FBet32mcQ3g4mFIgmqpkGBw==}
+  alchemy@2.0.0-beta.63:
+    resolution: {integrity: sha512-NUcEK9a3cLltkWTTb5kVLH695X9MWO641n94Gi2AqqkU/9xj5QwHMluv9jQB3qDQ/l079F6TWXYf861t5zXEHA==}
     hasBin: true
     peerDependencies:
-      '@effect/platform-bun': '>=4.0.0-beta.93|| >=4.0.0'
-      '@effect/platform-node': '>=4.0.0-beta.93|| >=4.0.0'
-      '@effect/sql-pg': '>=4.0.0-beta.93|| >=4.0.0'
+      '@effect/platform-bun': '>=4.0.0-beta.97|| >=4.0.0'
+      '@effect/platform-node': '>=4.0.0-beta.97|| >=4.0.0'
+      '@effect/sql-pg': '>=4.0.0-beta.97|| >=4.0.0'
       drizzle-kit: '>=1.0.0-rc.1'
       drizzle-orm: '>=1.0.0-rc.1'
-      effect: '>=4.0.0-beta.93|| >=4.0.0'
+      effect: '>=4.0.0-beta.97|| >=4.0.0'
       vite: ^8.0.7
       ws: ^8.20.0
     peerDependenciesMeta:
@@ -5277,13 +5277,13 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@distilled.cloud/aws@0.28.2(effect@4.0.0-beta.97)':
+  '@distilled.cloud/aws@0.29.1(effect@4.0.0-beta.97)':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/credential-providers': 3.1081.0
       '@aws-sdk/types': 3.974.0
-      '@distilled.cloud/core': 0.28.2(effect@4.0.0-beta.97)
+      '@distilled.cloud/core': 0.29.1(effect@4.0.0-beta.97)
       '@smithy/shared-ini-file-loader': 4.6.8
       '@smithy/types': 4.16.1
       '@smithy/util-base64': 4.5.8
@@ -5291,12 +5291,12 @@ snapshots:
       effect: 4.0.0-beta.97
       fast-xml-parser: 5.8.0
 
-  '@distilled.cloud/axiom@0.28.2(effect@4.0.0-beta.97)':
+  '@distilled.cloud/axiom@0.29.1(effect@4.0.0-beta.97)':
     dependencies:
-      '@distilled.cloud/core': 0.28.2(effect@4.0.0-beta.97)
+      '@distilled.cloud/core': 0.29.1(effect@4.0.0-beta.97)
       effect: 4.0.0-beta.97
 
-  '@distilled.cloud/cloudflare-rolldown-plugin@0.12.2(rolldown@1.0.1)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(workerd@1.20260708.1)':
+  '@distilled.cloud/cloudflare-rolldown-plugin@0.13.5(rolldown@1.0.1)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(workerd@1.20260708.1)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260708.1)
       magic-string: 0.30.21
@@ -5307,20 +5307,20 @@ snapshots:
     transitivePeerDependencies:
       - workerd
 
-  '@distilled.cloud/cloudflare-runtime@0.12.2(@distilled.cloud/cloudflare@0.28.2(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97)':
+  '@distilled.cloud/cloudflare-runtime@0.13.5(@distilled.cloud/cloudflare@0.29.1(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97)':
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
-      '@distilled.cloud/cloudflare': 0.28.2(effect@4.0.0-beta.97)
+      '@distilled.cloud/cloudflare': 0.29.1(effect@4.0.0-beta.97)
       effect: 4.0.0-beta.97
       workerd: 1.20260704.1
     optionalDependencies:
       '@effect/platform-node': 4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1)
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.12.2(@distilled.cloud/cloudflare-runtime@0.12.2(@distilled.cloud/cloudflare@0.28.2(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97))(@distilled.cloud/cloudflare@0.28.2(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97)(rolldown@1.0.1)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(workerd@1.20260708.1)':
+  '@distilled.cloud/cloudflare-vite-plugin@0.13.5(@distilled.cloud/cloudflare-runtime@0.13.5(@distilled.cloud/cloudflare@0.29.1(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97))(@distilled.cloud/cloudflare@0.29.1(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97)(rolldown@1.0.1)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(workerd@1.20260708.1)':
     dependencies:
-      '@distilled.cloud/cloudflare': 0.28.2(effect@4.0.0-beta.97)
-      '@distilled.cloud/cloudflare-rolldown-plugin': 0.12.2(rolldown@1.0.1)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(workerd@1.20260708.1)
-      '@distilled.cloud/cloudflare-runtime': 0.12.2(@distilled.cloud/cloudflare@0.28.2(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97)
+      '@distilled.cloud/cloudflare': 0.29.1(effect@4.0.0-beta.97)
+      '@distilled.cloud/cloudflare-rolldown-plugin': 0.13.5(rolldown@1.0.1)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(workerd@1.20260708.1)
+      '@distilled.cloud/cloudflare-runtime': 0.13.5(@distilled.cloud/cloudflare@0.29.1(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97)
       effect: 4.0.0-beta.97
       vite: 7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
     optionalDependencies:
@@ -5329,23 +5329,23 @@ snapshots:
       - rolldown
       - workerd
 
-  '@distilled.cloud/cloudflare@0.28.2(effect@4.0.0-beta.97)':
+  '@distilled.cloud/cloudflare@0.29.1(effect@4.0.0-beta.97)':
     dependencies:
-      '@distilled.cloud/core': 0.28.2(effect@4.0.0-beta.97)
+      '@distilled.cloud/core': 0.29.1(effect@4.0.0-beta.97)
       effect: 4.0.0-beta.97
 
-  '@distilled.cloud/core@0.28.2(effect@4.0.0-beta.97)':
+  '@distilled.cloud/core@0.29.1(effect@4.0.0-beta.97)':
     dependencies:
       effect: 4.0.0-beta.97
 
-  '@distilled.cloud/neon@0.28.2(effect@4.0.0-beta.97)':
+  '@distilled.cloud/neon@0.29.1(effect@4.0.0-beta.97)':
     dependencies:
-      '@distilled.cloud/core': 0.28.2(effect@4.0.0-beta.97)
+      '@distilled.cloud/core': 0.29.1(effect@4.0.0-beta.97)
       effect: 4.0.0-beta.97
 
-  '@distilled.cloud/planetscale@0.28.2(effect@4.0.0-beta.97)':
+  '@distilled.cloud/planetscale@0.29.1(effect@4.0.0-beta.97)':
     dependencies:
-      '@distilled.cloud/core': 0.28.2(effect@4.0.0-beta.97)
+      '@distilled.cloud/core': 0.29.1(effect@4.0.0-beta.97)
       effect: 4.0.0-beta.97
 
   '@effect/platform-node-shared@4.0.0-beta.98(effect@4.0.0-beta.97)':
@@ -6779,20 +6779,20 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alchemy@2.0.0-beta.61(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(@types/node@25.9.5)(@types/react@19.2.17)(effect@4.0.0-beta.97)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.1.10)(workerd@1.20260708.1)(ws@8.21.0):
+  alchemy@2.0.0-beta.63(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(@types/node@25.9.5)(@types/react@19.2.17)(effect@4.0.0-beta.97)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.1.10)(workerd@1.20260708.1)(ws@8.21.0):
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1081.0
       '@clack/prompts': 0.11.0
-      '@distilled.cloud/aws': 0.28.2(effect@4.0.0-beta.97)
-      '@distilled.cloud/axiom': 0.28.2(effect@4.0.0-beta.97)
-      '@distilled.cloud/cloudflare': 0.28.2(effect@4.0.0-beta.97)
-      '@distilled.cloud/cloudflare-rolldown-plugin': 0.12.2(rolldown@1.0.1)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(workerd@1.20260708.1)
-      '@distilled.cloud/cloudflare-runtime': 0.12.2(@distilled.cloud/cloudflare@0.28.2(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97)
-      '@distilled.cloud/cloudflare-vite-plugin': 0.12.2(@distilled.cloud/cloudflare-runtime@0.12.2(@distilled.cloud/cloudflare@0.28.2(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97))(@distilled.cloud/cloudflare@0.28.2(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97)(rolldown@1.0.1)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(workerd@1.20260708.1)
-      '@distilled.cloud/core': 0.28.2(effect@4.0.0-beta.97)
-      '@distilled.cloud/neon': 0.28.2(effect@4.0.0-beta.97)
-      '@distilled.cloud/planetscale': 0.28.2(effect@4.0.0-beta.97)
+      '@distilled.cloud/aws': 0.29.1(effect@4.0.0-beta.97)
+      '@distilled.cloud/axiom': 0.29.1(effect@4.0.0-beta.97)
+      '@distilled.cloud/cloudflare': 0.29.1(effect@4.0.0-beta.97)
+      '@distilled.cloud/cloudflare-rolldown-plugin': 0.13.5(rolldown@1.0.1)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(workerd@1.20260708.1)
+      '@distilled.cloud/cloudflare-runtime': 0.13.5(@distilled.cloud/cloudflare@0.29.1(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97)
+      '@distilled.cloud/cloudflare-vite-plugin': 0.13.5(@distilled.cloud/cloudflare-runtime@0.13.5(@distilled.cloud/cloudflare@0.29.1(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97))(@distilled.cloud/cloudflare@0.29.1(effect@4.0.0-beta.97))(@effect/platform-node@4.0.0-beta.97(effect@4.0.0-beta.97)(ioredis@5.11.1))(effect@4.0.0-beta.97)(rolldown@1.0.1)(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))(workerd@1.20260708.1)
+      '@distilled.cloud/core': 0.29.1(effect@4.0.0-beta.97)
+      '@distilled.cloud/neon': 0.29.1(effect@4.0.0-beta.97)
+      '@distilled.cloud/planetscale': 0.29.1(effect@4.0.0-beta.97)
       '@effect/vitest': 4.0.0-beta.97(effect@4.0.0-beta.97)(vitest@4.1.10)
       '@libsql/client': 0.17.4
       '@octokit/rest': 22.0.1


### PR DESCRIPTION
beta.61 は effect の旧 API（Schedule.either）に依存しており、
CI での deploy が TypeError で失敗していた。beta.63 は
effect >= 4.0.0-beta.97 を要求し、現在の依存関係と整合する。

Entire-Checkpoint: d2f87a56d998