### PR TITLE
fix: 内部メディアストレージを無効化し画像を R2 のみに

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -10,11 +10,11 @@ backend:
   # OAuth プロキシ（sveltia-cms-auth）。infra/alchemy.run.ts で管理。
   base_url: https://sveltia-auth.ta93abe.com
 
-# 内部メディア（R2 を使わない場合のフォールバック先）
-media_folder: public/uploads
-public_folder: /uploads
-
-# 画像アップロード先を R2 に
+# 画像アップロード先は R2 のみ。
+# media_folder を定義しないことで内部メディアストレージ（Git リポジトリへの
+# コミット）を無効化している。内部ストレージ経由だと画像が GitHub API の
+# 1 コミットに載り、45MB のペイロード上限に当たるため使わない。
+# https://sveltiacms.app/en/docs/media/internal
 # https://sveltiacms.app/en/docs/media/cloudflare-r2
 media_libraries:
   cloudflare_r2:


### PR DESCRIPTION
media_folder が定義されていると、ドラッグ&ドロップ等のアップロードが
内部ストレージ（Git リポジトリへのコミット）に流れ、GitHub API の
45MB ペイロード上限で保存が失敗する。media_folder を省略して
内部ストレージを無効化し、画像は常に R2 へアップロードさせる。

Entire-Checkpoint: c97155200448