### PR TITLE
fix: 空のオプショナルフィールドの出力を止めてビルド失敗を解消

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -10,6 +10,13 @@ backend:
   # OAuth プロキシ（sveltia-cms-auth）。infra/alchemy.run.ts で管理。
   base_url: https://sveltia-auth.ta93abe.com
 
+output:
+  # 空のオプショナルフィールドをフロントマターから省略する。
+  # デフォルトでは updatedDate: '' のような空文字列が保存され、
+  # Astro の z.coerce.date() がパースできずビルドが失敗する。
+  # https://sveltiacms.app/en/docs/data-output
+  omit_empty_optional_fields: true
+
 # 画像アップロード先は R2 のみ。
 # media_folder を定義しないことで内部メディアストレージ（Git リポジトリへの
 # コミット）を無効化している。内部ストレージ経由だと画像が GitHub API の

--- a/src/content/blog/first-post.md
+++ b/src/content/blog/first-post.md
@@ -1,7 +1,6 @@
 ---
 title: 最初のブログ投稿
 date: 2026-07-18
-updatedDate: ''
 excerpt: ブログを始めました。
 ---
 

--- a/src/content/blog/テスト投稿.md
+++ b/src/content/blog/テスト投稿.md
@@ -1,7 +1,6 @@
 ---
 title: テスト投稿
 date: 2026-07-18
-updatedDate: ''
 excerpt: ブログ書くぜ
 tags: []
 ---


### PR DESCRIPTION
Sveltia CMS はデフォルトで空の updatedDate を '' として保存するため、
Astro の z.coerce.date() がパースできず main のビルドが落ちていた。

- output.omit_empty_optional_fields: true を設定
- 既に保存されてしまった updatedDate: '' を 2 記事から削除

Entire-Checkpoint: c34344ce4693