### PR TITLE
feat: スラッグをタイトルと独立して編集可能にする

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -40,7 +40,10 @@ collections:
     create: true
     extension: md
     format: yaml-frontmatter
-    slug: "{{slug}}"
+    # エントリ編集画面にスラッグ専用エディタを表示し、タイトルとは独立して
+    # ファイル名（= URL）を指定できるようにする。
+    # https://sveltiacms.app/en/docs/collections/entries
+    slug: "{{fields._slug}}"
     fields:
       - { name: title, label: タイトル }
       - {


### PR DESCRIPTION
slug オプションを {{fields._slug}} に変更し、エントリ編集画面に
専用のスラッグエディタを表示する。日本語タイトルでもファイル名
（= URL)を任意の英数字スラッグにできる。

Entire-Checkpoint: 4e4648b27f68