### PR TITLE
feat: クリーム基調のエディトリアルデザインに刷新

### DIFF
--- a/src/components/FilterSort.astro
+++ b/src/components/FilterSort.astro
@@ -56,7 +56,7 @@ const uniqueTags = [...new Set(tags)].toSorted();
         </label>
         <select
           id={`sort-${containerId}`}
-          class="sort-select rounded-lg border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm transition-colors focus:border-[var(--primary-color)] focus:outline-none focus:ring-2 focus:ring-[var(--primary-color)] focus:ring-offset-1"
+          class="sort-select rounded-lg border border-(--border-color) bg-[var(--bg-elevated)] px-3 py-1.5 text-sm transition-colors focus:border-[var(--primary-color)] focus:outline-none focus:ring-2 focus:ring-[var(--primary-color)] focus:ring-offset-1"
         >
           {sortOptions.map((option) => (
             <option value={option.value}>{option.label}</option>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,7 +4,7 @@ import { SITE } from "../config/site";
 const currentYear = new Date().getFullYear();
 ---
 
-<footer class="border-t border-white/5 bg-[var(--bg-secondary)]" role="contentinfo">
+<footer class="border-t border-(--border-color) bg-[var(--bg-secondary)]" role="contentinfo">
   <div class="mx-auto max-w-7xl px-6 py-10">
     <div class="flex flex-col items-center gap-4">
       <a

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,10 +6,10 @@ import NavLink from "./ui/NavLink.astro";
 ---
 
 <header
-  class="fixed top-0 left-0 right-0 z-50 border-b border-(--border-color) bg-[var(--bg-primary)]/80 backdrop-blur-xl"
+  class="sticky top-0 z-50 border-b border-(--border-color) bg-[var(--bg-primary)]/80 backdrop-blur-xl"
 >
   <nav
-    class="mx-auto flex max-w-7xl items-center justify-between px-6 py-4"
+    class="mx-auto flex h-[var(--header-height)] max-w-7xl items-center justify-between px-6"
     aria-label="メインナビゲーション"
   >
     <Logo />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,7 +6,7 @@ import NavLink from "./ui/NavLink.astro";
 ---
 
 <header
-  class="fixed top-0 left-0 right-0 z-50 border-b border-white/5 bg-[var(--bg-primary)]/70 backdrop-blur-xl"
+  class="fixed top-0 left-0 right-0 z-50 border-b border-(--border-color) bg-[var(--bg-primary)]/80 backdrop-blur-xl"
 >
   <nav
     class="mx-auto flex max-w-7xl items-center justify-between px-6 py-4"
@@ -34,7 +34,7 @@ import NavLink from "./ui/NavLink.astro";
       <button
         type="button"
         id="mobile-menu-button"
-        class="flex h-10 w-10 items-center justify-center rounded-lg border border-white/10 bg-white/5 hover:bg-white/10 transition-colors"
+        class="flex h-10 w-10 items-center justify-center rounded-lg border border-(--border-color) bg-[var(--bg-elevated)] hover:bg-[var(--bg-tertiary)] transition-colors"
         aria-label="メニューを開く"
         aria-expanded="false"
         aria-controls="mobile-menu"
@@ -74,7 +74,7 @@ import NavLink from "./ui/NavLink.astro";
   <!-- モバイルメニュー -->
   <div
     id="mobile-menu"
-    class="hidden border-t border-white/5 bg-[var(--bg-primary)]/95 backdrop-blur-xl md:hidden"
+    class="hidden border-t border-(--border-color) bg-[var(--bg-primary)]/95 backdrop-blur-xl md:hidden"
     aria-hidden="true"
   >
     <ul class="space-y-1 px-6 py-4">
@@ -83,7 +83,7 @@ import NavLink from "./ui/NavLink.astro";
           <li>
             <NavLink
               href={link.href}
-              class="block rounded-lg px-4 py-3 text-lg hover:bg-white/5"
+              class="block rounded-lg px-4 py-3 text-lg hover:bg-[var(--bg-secondary)]"
             >
               {link.text}
             </NavLink>

--- a/src/components/Skeleton.astro
+++ b/src/components/Skeleton.astro
@@ -19,7 +19,7 @@ const variantClasses = {
 };
 
 const variantClass = variantClasses[variant];
-const classes = cn("animate-pulse bg-neutral-700", variantClass, className);
+const classes = cn("animate-pulse bg-[var(--bg-tertiary)]", variantClass, className);
 
 let style = "";
 if (width) {

--- a/src/components/blog/LinkCard.astro
+++ b/src/components/blog/LinkCard.astro
@@ -18,13 +18,13 @@ const domain = new URL(href).hostname.replace("www.", "");
   class="my-6 flex items-center gap-4 rounded-lg border border-(--border-color) p-4 transition-all hover:border-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:shadow-sm no-underline"
 >
   <div class="flex-1 min-w-0">
-    <div class="font-semibold text-neutral-100 truncate">{title}</div>
+    <div class="font-semibold text-[var(--text-primary)] truncate">{title}</div>
     {
       description && (
-        <div class="mt-1 text-sm text-neutral-400 line-clamp-2">{description}</div>
+        <div class="mt-1 text-sm text-[var(--text-secondary)] line-clamp-2">{description}</div>
       )
     }
-    <div class="mt-2 flex items-center gap-1 text-xs text-neutral-500">
+    <div class="mt-2 flex items-center gap-1 text-xs text-[var(--text-muted)]">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
@@ -48,7 +48,7 @@ const domain = new URL(href).hostname.replace("www.", "");
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"
       fill="currentColor"
-      class="size-5 text-neutral-500"
+      class="size-5 text-[var(--text-muted)]"
     >
       <path
         fill-rule="evenodd"

--- a/src/components/blog/LinkCard.astro
+++ b/src/components/blog/LinkCard.astro
@@ -15,7 +15,7 @@ const domain = new URL(href).hostname.replace("www.", "");
   href={href}
   target="_blank"
   rel="noopener noreferrer"
-  class="my-6 flex items-center gap-4 rounded-lg border border-neutral-800 p-4 transition-all hover:border-neutral-700 hover:bg-neutral-900 hover:shadow-sm no-underline"
+  class="my-6 flex items-center gap-4 rounded-lg border border-(--border-color) p-4 transition-all hover:border-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:shadow-sm no-underline"
 >
   <div class="flex-1 min-w-0">
     <div class="font-semibold text-neutral-100 truncate">{title}</div>

--- a/src/components/blog/OgpCard.astro
+++ b/src/components/blog/OgpCard.astro
@@ -16,17 +16,17 @@ const ogp = await fetchOgpData(url);
   class="my-6 flex rounded-lg border border-(--border-color) transition-all hover:border-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:shadow-sm no-underline overflow-hidden"
 >
   <div class="flex-1 min-w-0 p-4">
-    <div class="font-semibold text-neutral-100 truncate text-sm">
+    <div class="font-semibold text-[var(--text-primary)] truncate text-sm">
       {ogp.title}
     </div>
     {
       ogp.description && (
-        <div class="mt-1 text-xs text-neutral-400 line-clamp-2">
+        <div class="mt-1 text-xs text-[var(--text-secondary)] line-clamp-2">
           {ogp.description}
         </div>
       )
     }
-    <div class="mt-2 flex items-center gap-1.5 text-xs text-neutral-500">
+    <div class="mt-2 flex items-center gap-1.5 text-xs text-[var(--text-muted)]">
       <img
         src={ogp.favicon}
         alt=""

--- a/src/components/blog/OgpCard.astro
+++ b/src/components/blog/OgpCard.astro
@@ -13,7 +13,7 @@ const ogp = await fetchOgpData(url);
   href={ogp.url}
   target="_blank"
   rel="noopener noreferrer"
-  class="my-6 flex rounded-lg border border-neutral-800 transition-all hover:border-neutral-700 hover:bg-neutral-900 hover:shadow-sm no-underline overflow-hidden"
+  class="my-6 flex rounded-lg border border-(--border-color) transition-all hover:border-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:shadow-sm no-underline overflow-hidden"
 >
   <div class="flex-1 min-w-0 p-4">
     <div class="font-semibold text-neutral-100 truncate text-sm">

--- a/src/components/landing/HeroSection.astro
+++ b/src/components/landing/HeroSection.astro
@@ -41,7 +41,8 @@ import Button from "../ui/Button.astro";
 <style>
   .hero-section {
     position: relative;
-    min-height: 100dvh;
+    /* sticky ヘッダーの高さを差し引いて 1 画面に収める */
+    min-height: calc(100dvh - var(--header-height));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -211,7 +212,7 @@ import Button from "../ui/Button.astro";
 
   @media (max-width: 768px) {
     .hero-section {
-      min-height: 100svh;
+      min-height: calc(100svh - var(--header-height));
     }
 
     .hero-orb-1 {

--- a/src/components/landing/HeroSection.astro
+++ b/src/components/landing/HeroSection.astro
@@ -47,7 +47,7 @@ import Button from "../ui/Button.astro";
     justify-content: center;
     overflow: hidden;
     background:
-      radial-gradient(ellipse at 50% 0%, rgba(129, 140, 248, 0.12) 0%, transparent 50%),
+      radial-gradient(ellipse at 50% 0%, rgba(166, 61, 42, 0.06) 0%, transparent 50%),
       var(--bg-primary);
   }
 
@@ -55,8 +55,8 @@ import Button from "../ui/Button.astro";
     position: absolute;
     inset: 0;
     background-image:
-      linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+      linear-gradient(rgba(43, 38, 32, 0.05) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(43, 38, 32, 0.05) 1px, transparent 1px);
     background-size: 60px 60px;
     mask-image: radial-gradient(ellipse at center, black 0%, transparent 70%);
     -webkit-mask-image: radial-gradient(ellipse at center, black 0%, transparent 70%);
@@ -67,7 +67,7 @@ import Button from "../ui/Button.astro";
     position: absolute;
     border-radius: 50%;
     filter: blur(80px);
-    opacity: 0.5;
+    opacity: 0.35;
     pointer-events: none;
     will-change: transform;
   }
@@ -75,7 +75,7 @@ import Button from "../ui/Button.astro";
   .hero-orb-1 {
     width: 500px;
     height: 500px;
-    background: linear-gradient(135deg, #818cf8, #c084fc);
+    background: linear-gradient(135deg, #d9b98a, #c98e6a);
     top: -150px;
     right: -100px;
     animation: float 12s ease-in-out infinite;
@@ -84,7 +84,7 @@ import Button from "../ui/Button.astro";
   .hero-orb-2 {
     width: 400px;
     height: 400px;
-    background: linear-gradient(135deg, #60a5fa, #818cf8);
+    background: linear-gradient(135deg, #c9bfa0, #d9b98a);
     bottom: -100px;
     left: -100px;
     animation: float 14s ease-in-out infinite reverse;
@@ -93,7 +93,7 @@ import Button from "../ui/Button.astro";
   .hero-orb-3 {
     width: 300px;
     height: 300px;
-    background: linear-gradient(135deg, #c084fc, #f472b6);
+    background: linear-gradient(135deg, #ce8f6d, #b96a4f);
     top: 40%;
     left: 30%;
     opacity: 0.25;
@@ -126,8 +126,8 @@ import Button from "../ui/Button.astro";
     gap: 0.5rem;
     padding: 0.5rem 1rem;
     border-radius: 9999px;
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(43, 38, 32, 0.04);
+    border: 1px solid var(--border-color);
     font-size: 0.8125rem;
     color: var(--text-secondary);
     margin-bottom: 2rem;
@@ -138,8 +138,8 @@ import Button from "../ui/Button.astro";
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: #34d399;
-    box-shadow: 0 0 8px #34d399;
+    background: var(--primary-color);
+    box-shadow: 0 0 8px rgba(166, 61, 42, 0.5);
     animation: pulse 2s ease-in-out infinite;
   }
 
@@ -162,7 +162,7 @@ import Button from "../ui/Button.astro";
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
-    filter: drop-shadow(0 0 40px rgba(129, 140, 248, 0.3));
+    filter: drop-shadow(0 2px 24px rgba(90, 66, 34, 0.15));
   }
 
   .hero-description {

--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -6,7 +6,7 @@ const button = tv({
 	variants: {
 		variant: {
 			primary:
-				"relative overflow-hidden bg-[var(--text-primary)] text-[var(--bg-primary)] hover:shadow-[0_0_30px_-5px_rgba(129,140,248,0.4)] before:absolute before:inset-0 before:bg-gradient-to-r before:from-[var(--primary-color)] before:to-[var(--accent-color)] before:opacity-0 before:transition-opacity hover:before:opacity-100",
+				"relative overflow-hidden bg-[var(--text-primary)] text-[var(--bg-primary)] hover:shadow-[0_0_30px_-5px_rgba(166,61,42,0.35)] before:absolute before:inset-0 before:bg-gradient-to-r before:from-[var(--primary-color)] before:to-[var(--accent-color)] before:opacity-0 before:transition-opacity hover:before:opacity-100",
 			secondary:
 				"bg-transparent text-[var(--text-primary)] border border-(--border-color) hover:border-[var(--primary-color)]/50 hover:bg-[var(--bg-secondary)]",
 			ghost:

--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -8,9 +8,9 @@ const button = tv({
 			primary:
 				"relative overflow-hidden bg-[var(--text-primary)] text-[var(--bg-primary)] hover:shadow-[0_0_30px_-5px_rgba(129,140,248,0.4)] before:absolute before:inset-0 before:bg-gradient-to-r before:from-[var(--primary-color)] before:to-[var(--accent-color)] before:opacity-0 before:transition-opacity hover:before:opacity-100",
 			secondary:
-				"bg-transparent text-[var(--text-primary)] border border-white/20 hover:border-[var(--primary-color)]/50 hover:bg-white/5",
+				"bg-transparent text-[var(--text-primary)] border border-(--border-color) hover:border-[var(--primary-color)]/50 hover:bg-[var(--bg-secondary)]",
 			ghost:
-				"bg-transparent text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-white/5",
+				"bg-transparent text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-secondary)]",
 		},
 		size: {
 			sm: "px-4 py-2 text-sm",

--- a/src/components/ui/Card.astro
+++ b/src/components/ui/Card.astro
@@ -5,9 +5,9 @@ const card = tv({
 	base: "rounded-xl p-6 transition-all duration-200",
 	variants: {
 		variant: {
-			default: "bg-neutral-900 shadow-sm",
-			outline: "bg-transparent border border-neutral-800",
-			elevated: "bg-neutral-900 shadow-lg",
+			default: "bg-[var(--bg-elevated)] shadow-sm",
+			outline: "bg-transparent border border-(--border-color)",
+			elevated: "bg-[var(--bg-elevated)] shadow-lg",
 		},
 		clickable: {
 			true: "hover:shadow-md hover:translate-y-[-2px] cursor-pointer",

--- a/src/components/ui/CardSkeleton.astro
+++ b/src/components/ui/CardSkeleton.astro
@@ -6,9 +6,9 @@ const cardSkeleton = tv({
 	base: "animate-pulse",
 	variants: {
 		variant: {
-			blog: "border-b border-neutral-800 pb-8",
-			work: "overflow-hidden rounded-lg border border-neutral-800",
-			book: "overflow-hidden rounded-lg border border-neutral-800",
+			blog: "border-b border-(--border-color) pb-8",
+			work: "overflow-hidden rounded-lg border border-(--border-color)",
+			book: "overflow-hidden rounded-lg border border-(--border-color)",
 		},
 	},
 	defaultVariants: {

--- a/src/components/ui/FilterChip.astro
+++ b/src/components/ui/FilterChip.astro
@@ -7,7 +7,7 @@ const filterChip = tv({
 		active: {
 			true: "border-[var(--primary-color)] bg-[var(--primary-color)] text-white",
 			false:
-				"border-neutral-700 bg-neutral-900 text-neutral-300 hover:border-[var(--primary-color)] hover:text-[var(--primary-color)]",
+				"border-(--border-color) bg-[var(--bg-elevated)] text-[var(--text-secondary)] hover:border-[var(--primary-color)] hover:text-[var(--primary-color)]",
 		},
 	},
 	defaultVariants: {

--- a/src/components/ui/Input.astro
+++ b/src/components/ui/Input.astro
@@ -7,10 +7,10 @@ const input = tv({
 		error: {
 			true: "border-red-500 bg-red-950/40 text-neutral-100 focus:border-red-500 focus:ring-red-500",
 			false:
-				"border-neutral-700 bg-neutral-900 text-neutral-100 placeholder-neutral-500 focus:border-[var(--primary-color)] focus:ring-[var(--primary-color)]",
+				"border-(--border-color) bg-[var(--bg-elevated)] text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:border-[var(--primary-color)] focus:ring-[var(--primary-color)]",
 		},
 		disabled: {
-			true: "opacity-50 cursor-not-allowed bg-neutral-800",
+			true: "opacity-50 cursor-not-allowed bg-[var(--bg-tertiary)]",
 			false: "",
 		},
 	},

--- a/src/components/ui/Input.astro
+++ b/src/components/ui/Input.astro
@@ -5,7 +5,7 @@ const input = tv({
 	base: "w-full rounded-lg border px-4 py-2.5 text-base transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-1",
 	variants: {
 		error: {
-			true: "border-red-500 bg-red-950/40 text-neutral-100 focus:border-red-500 focus:ring-red-500",
+			true: "border-red-600 bg-red-50 text-[var(--text-primary)] focus:border-red-600 focus:ring-red-500",
 			false:
 				"border-(--border-color) bg-[var(--bg-elevated)] text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:border-[var(--primary-color)] focus:ring-[var(--primary-color)]",
 		},
@@ -54,7 +54,7 @@ const classes = input({ error: !!error, disabled, class: className });
 		label && (
 			<label
 				for={id}
-				class="text-sm font-medium text-neutral-300"
+				class="text-sm font-medium text-[var(--text-secondary)]"
 			>
 				{label}
 				{required && <span class="text-red-500">*</span>}

--- a/src/components/ui/Select.astro
+++ b/src/components/ui/Select.astro
@@ -2,11 +2,11 @@
 import { tv } from "tailwind-variants";
 
 const select = tv({
-	base: "rounded-lg border bg-neutral-900 px-3 py-1.5 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1",
+	base: "rounded-lg border bg-[var(--bg-elevated)] px-3 py-1.5 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1",
 	variants: {
 		variant: {
 			default:
-				"border-neutral-700 focus:border-[var(--primary-color)] focus:ring-[var(--primary-color)]",
+				"border-(--border-color) focus:border-[var(--primary-color)] focus:ring-[var(--primary-color)]",
 		},
 		size: {
 			sm: "px-2 py-1 text-xs",

--- a/src/components/ui/Skeleton.astro
+++ b/src/components/ui/Skeleton.astro
@@ -2,7 +2,7 @@
 import { tv } from "tailwind-variants";
 
 const skeleton = tv({
-	base: "animate-pulse bg-neutral-700",
+	base: "animate-pulse bg-[var(--bg-tertiary)]",
 	variants: {
 		variant: {
 			text: "h-4 rounded",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -39,7 +39,8 @@ const ogImageURL = new URL(ogImage, Astro.site);
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
-		<meta name="color-scheme" content="dark" />
+		<meta name="color-scheme" content="light" />
+		<meta name="theme-color" content="#f6f1e6" />
 
 		<!-- Primary Meta Tags -->
 		<title>{title}</title>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,6 +17,7 @@
  * - アクセントは朱（しゅ）と黄土。和文エディトリアルの差し色
  */
 :root {
+	--header-height: 4rem;
 	--primary-color: #a63d2a; /* 朱 */
 	--primary-hover: #8a3120;
 	--accent-color: #8a6d3b; /* 黄土 */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,39 +9,60 @@
 @import "@fontsource/inter/700.css";
 @plugin "@tailwindcss/typography";
 
-/* Dark theme color system */
+/* Editorial cream paper color system
+ *
+ * 紙面をモチーフにしたクリーム基調のライトテーマ。
+ * - 純白 / 純黒を避け、生成り紙 × セピアインクの低コントラストで
+ *   長時間の閲覧でも目が疲れないようにする
+ * - アクセントは朱（しゅ）と黄土。和文エディトリアルの差し色
+ */
 :root {
-	--primary-color: #818cf8;
-	--primary-hover: #6366f1;
-	--accent-color: #c084fc;
-	--bg-primary: #0a0a0b;
-	--bg-secondary: #111113;
-	--bg-tertiary: #1a1a1e;
-	--bg-elevated: #222226;
-	--text-primary: #f5f5f7;
-	--text-secondary: #a1a1aa;
-	--text-muted: #71717a;
-	--border-color: #27272a;
-	--link-color: #818cf8;
-	--link-hover-color: #a5b4fc;
-	--blockquote-bg: rgba(129, 140, 248, 0.08);
-	--blockquote-border: #818cf8;
-	--code-bg: #1a1a1e;
-	--code-text: #e4e4e7;
+	--primary-color: #a63d2a; /* 朱 */
+	--primary-hover: #8a3120;
+	--accent-color: #8a6d3b; /* 黄土 */
+	--bg-primary: #f6f1e6; /* 生成りの紙 */
+	--bg-secondary: #efe8d9; /* 一段深い紙 */
+	--bg-tertiary: #e7deca; /* カード・小口 */
+	--bg-elevated: #fbf7ee; /* 貼り込んだ白紙 */
+	--text-primary: #2b2620; /* 墨（セピア寄り） */
+	--text-secondary: #5a5244;
+	--text-muted: #8a8071;
+	--border-color: #ddd2bb;
+	--link-color: #a63d2a;
+	--link-hover-color: #8a3120;
+	--blockquote-bg: rgba(166, 61, 42, 0.06);
+	--blockquote-border: #a63d2a;
+	--code-bg: #2a2522; /* コードは墨版（ダーク）のまま */
+	--code-text: #ece5d8;
 }
 
 /* Base */
 html {
 	scroll-behavior: smooth;
+	background-color: var(--bg-primary);
 }
 
 body {
-	font-family:
-		"Inter", "Shippori Mincho", "Noto Serif JP", system-ui, sans-serif;
+	font-family: "Noto Serif JP", "Shippori Mincho", "Georgia", serif;
 	background-color: var(--bg-primary);
 	color: var(--text-primary);
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+}
+
+/* 紙のざらつき（フラクタルノイズのグレイン）
+ * 画面全体に固定オーバーレイとして重ねる。multiply で紙色に沈むため
+ * 発光感がなく、ごく低い不透明度でテクスチャだけが残る */
+body::before {
+	content: "";
+	position: fixed;
+	inset: 0;
+	z-index: 9999;
+	pointer-events: none;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+	background-size: 240px 240px;
+	opacity: 0.05;
+	mix-blend-mode: multiply;
 }
 
 /* Focus */
@@ -75,16 +96,16 @@ body {
 	background-clip: text;
 }
 
-/* Glow effects */
+/* Glow effects（紙面ではインクの滲みのような柔らかい影に） */
 .glow {
-	box-shadow: 0 0 40px -10px rgba(129, 140, 248, 0.3);
+	box-shadow: 0 2px 24px -6px rgba(90, 66, 34, 0.25);
 }
 
 .glow-strong {
-	box-shadow: 0 0 80px -20px rgba(129, 140, 248, 0.4);
+	box-shadow: 0 4px 48px -12px rgba(90, 66, 34, 0.35);
 }
 
-/* Editorial article body - dark */
+/* Editorial article body */
 .prose {
 	font-family: "Shippori Mincho", "Noto Serif JP", serif;
 	font-size: 1.0625rem;
@@ -296,10 +317,11 @@ body {
 	accent-color: var(--primary-color);
 }
 
-/* Image styling */
+/* Image styling（紙に貼った写真のような縁と影） */
 .prose img {
-	border-radius: 0.75rem;
-	box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.3);
+	border-radius: 0.25rem;
+	border: 1px solid var(--border-color);
+	box-shadow: 0 2px 12px -2px rgba(90, 66, 34, 0.18);
 }
 
 /* Link styling */
@@ -382,8 +404,8 @@ body {
 	}
 }
 
-/* Selection */
+/* Selection（蛍光ペンのような淡い朱） */
 ::selection {
-	background: rgba(129, 140, 248, 0.3);
+	background: rgba(166, 61, 42, 0.18);
 	color: var(--text-primary);
 }

--- a/src/utils/og/generate-og-image.ts
+++ b/src/utils/og/generate-og-image.ts
@@ -43,22 +43,22 @@ export async function generateOgImage(
 
 	const font = await loadFont();
 
-	// Color schemes based on content type
+	// Color schemes based on content type（サイト本体のクリーム基調に合わせる）
 	const colorSchemes = {
 		blog: {
-			background: "linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%)",
-			accent: "#60a5fa",
-			text: "#f1f5f9",
+			background: "linear-gradient(135deg, #f6f1e6 0%, #efe8d9 100%)",
+			accent: "#a63d2a",
+			text: "#2b2620",
 		},
 		works: {
-			background: "linear-gradient(135deg, #4c1d95 0%, #1e1b4b 100%)",
-			accent: "#a78bfa",
-			text: "#f1f5f9",
+			background: "linear-gradient(135deg, #f6f1e6 0%, #e7deca 100%)",
+			accent: "#8a6d3b",
+			text: "#2b2620",
 		},
 		default: {
-			background: "linear-gradient(135deg, #1a1a1a 0%, #0a0a0a 100%)",
-			accent: "#818cf8",
-			text: "#f5f5f5",
+			background: "linear-gradient(135deg, #fbf7ee 0%, #efe8d9 100%)",
+			accent: "#a63d2a",
+			text: "#2b2620",
 		},
 	};
 


### PR DESCRIPTION
## Summary

ダークテーマから、紙面をモチーフにしたクリーム基調のエディトリアルデザインへ全面刷新する。

- **配色**: 生成り紙（`#f6f1e6`）× セピア墨（`#2b2620`）の低コントラスト。純白・純黒を避け、長時間の閲覧でも目が疲れないようにする。アクセントは朱（`#a63d2a`）と黄土（`#8a6d3b`）
- **紙のざらつき**: `feTurbulence` の SVG フラクタルノイズを `mix-blend-mode: multiply` + 不透明度 5% で全面に重ね、印刷物のようなグレインを表現（画像アセット不要・CSS のみ）
- **タイポグラフィ**: 本文をセリフ（Noto Serif JP / Shippori Mincho）基調に変更しエディトリアルの読み味に
- **コードブロック**: 墨版（ダーク）のまま残し、紙面に対するコントラスト要素として活用
- **波及修正**: `bg-neutral-900` や `border-white/5` などダーク前提のハードコードを CSS 変数ベースに置換（13 ファイル）。ヒーローのオーブ・OG 画像も暖色パレットに統一

## Verification

- `pnpm lint` / `pnpm format` / `pnpm build` パス
- `pnpm preview` + Playwright でホーム / ブログ記事 / Links / Bookshelf を目視確認
- `prefers-reduced-motion` の既存対応は変更なし
