### PR TITLE
fix: CSP 互換のためシンタックスハイライトを Prism に切り替え

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,18 +19,16 @@ export default defineConfig({
 		defaultStrategy: "hover",
 	},
 	// Astro 7 デフォルトの Sätteri（Rust）で Markdown/MDX を処理。
-	// GFM / SmartyPants は標準搭載のため remark-gfm は不要。
+	// CSP と併用するためシンタックスハイライトは Prism（クラスベース）を使う。
+	// Shiki はインライン style 属性前提で Astro CSP と非互換。
 	markdown: {
-		shikiConfig: {
-			theme: "github-dark",
-			wrap: true,
-		},
+		syntaxHighlight: "prism",
 	},
 	// エージェント向けは `astro dev --json` / `pnpm dev:json` を使う
 	logger: logHandlers.console({ pretty: true }),
 	// Astro 7.1: ハッシュベース CSP + style-src-attr / script-src-elem
 	// PostHog の動的 script 注入は strict-dynamic で許可する。
-	// Shiki のトークン色は style 属性のため style-src-attr に unsafe-inline を限定付与。
+	// style-src-attr の unsafe-inline は --delay 等の CSS 変数属性用（Prism 自体は不要）。
 	security: {
 		csp: {
 			algorithm: "SHA-256",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -193,6 +193,64 @@ body::before {
 	font-size: 0.875rem;
 	line-height: 1.6;
 	color: var(--code-text);
+	white-space: pre;
+	word-wrap: normal;
+}
+
+/* Prism tokens — github-dark 相当（墨版コードブロック向け） */
+.prose pre .token.comment,
+.prose pre .token.prolog,
+.prose pre .token.doctype,
+.prose pre .token.cdata {
+	color: #8b949e;
+}
+
+.prose pre .token.punctuation {
+	color: #c9d1d9;
+}
+
+.prose pre .token.property,
+.prose pre .token.tag,
+.prose pre .token.boolean,
+.prose pre .token.number,
+.prose pre .token.constant,
+.prose pre .token.symbol,
+.prose pre .token.deleted {
+	color: #79c0ff;
+}
+
+.prose pre .token.selector,
+.prose pre .token.attr-name,
+.prose pre .token.string,
+.prose pre .token.char,
+.prose pre .token.builtin,
+.prose pre .token.inserted {
+	color: #a5d6ff;
+}
+
+.prose pre .token.operator,
+.prose pre .token.entity,
+.prose pre .token.url,
+.prose pre .language-css .token.string,
+.prose pre .style .token.string {
+	color: #ff7b72;
+}
+
+.prose pre .token.atrule,
+.prose pre .token.attr-value,
+.prose pre .token.keyword {
+	color: #ff7b72;
+}
+
+.prose pre .token.function,
+.prose pre .token.class-name {
+	color: #d2a8ff;
+}
+
+.prose pre .token.regex,
+.prose pre .token.important,
+.prose pre .token.variable {
+	color: #ffa657;
 }
 
 /* Code block copy button */


### PR DESCRIPTION
Astro は CSP 有効時に Shiki を非対応としているため、クラスベースの Prism へ移行する。

Entire-Checkpoint: d099f5c3c31e