### PR TITLE
fix: core-js のビルドスクリプトを allowBuilds で許可する

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ packages:
   - "."
 
 allowBuilds:
-  core-js: false
+  core-js: true
   esbuild: true
   msgpackr-extract: true
   sharp: true


### PR DESCRIPTION
pnpm approve-builds 相当の設定を明示し、依存の postinstall を許可する。

Entire-Checkpoint: fb3929212448