### PR TITLE
fix: ギャラリーリード文の折り返し位置を整える

### DIFF
--- a/src/pages/gallery/index.astro
+++ b/src/pages/gallery/index.astro
@@ -25,7 +25,8 @@ const sorted = [...pieces].toSorted((a, b) => {
 		<header class="gallery-header">
 			<h1 class="gallery-title font-display">ギャラリー</h1>
 			<p class="gallery-lead">
-				絵・写真・音楽の完成作品と、手がけたプロジェクトを余白を残して置いています。
+				絵・写真・音楽の完成作品と、<br />
+				手がけたプロジェクトを余白を残して置いています。
 			</p>
 		</header>
 


### PR DESCRIPTION
Entire-Checkpoint: 1295e82228f2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the gallery page header text layout by adding a line break for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->