### PR TITLE
feat: モバイルナビを Dialog 化し紙ノイズと Bookshelf 整理を追加

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,14 +2,15 @@
 // ヘッダーコンポーネント
 import { NAV_LINKS } from "@/config/navigation";
 import Logo from "./Logo.astro";
+import MobileNav from "./MobileNav";
 import NavLink from "./ui/NavLink.astro";
 ---
 
 <header
-  class="fixed inset-x-0 top-0 z-50 bg-transparent"
+  class="fixed inset-x-0 top-0 z-50 bg-transparent transition-colors data-[menu-open]:bg-(--bg-primary)"
 >
   <nav
-    class="mx-auto flex h-(--header-height) max-w-7xl items-center justify-between px-6"
+    class="relative mx-auto flex h-(--header-height) max-w-7xl items-center justify-between px-6"
     aria-label="メインナビゲーション"
   >
     <Logo />
@@ -29,113 +30,10 @@ import NavLink from "./ui/NavLink.astro";
       </ul>
     </div>
 
-    <!-- モバイル: ハンバーガー -->
-    <div class="flex items-center gap-2 md:hidden">
-      <button
-        type="button"
-        id="mobile-menu-button"
-        class="flex h-10 w-10 items-center justify-center rounded-md transition-colors hover:bg-(--bg-secondary)"
-        aria-label="メニューを開く"
-        aria-expanded="false"
-        aria-controls="mobile-menu"
-      >
-      <svg
-        id="menu-icon-open"
-        class="h-5 w-5"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M4 6h16M4 12h16M4 18h16"></path>
-      </svg>
-      <svg
-        id="menu-icon-close"
-        class="hidden h-5 w-5"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M6 18L18 6M6 6l12 12"></path>
-      </svg>
-      </button>
-    </div>
+    <MobileNav
+      client:load
+      links={NAV_LINKS}
+      currentPath={Astro.url.pathname}
+    />
   </nav>
-
-  <!-- モバイルメニュー -->
-  <div
-    id="mobile-menu"
-    class="hidden bg-transparent md:hidden"
-    aria-hidden="true"
-  >
-    <ul class="space-y-1 px-6 py-4">
-      {
-        NAV_LINKS.map((link) => (
-          <li>
-            <NavLink
-              href={link.href}
-              class="block rounded-lg px-4 py-3 text-lg hover:bg-(--bg-secondary)"
-            >
-              {link.text}
-            </NavLink>
-          </li>
-        ))
-      }
-    </ul>
-  </div>
 </header>
-
-<script>
-  const menuButton = document.getElementById("mobile-menu-button");
-  const mobileMenu = document.getElementById("mobile-menu");
-  const iconOpen = document.getElementById("menu-icon-open");
-  const iconClose = document.getElementById("menu-icon-close");
-
-  if (!menuButton || !mobileMenu || !iconOpen || !iconClose) {
-    console.error("Mobile menu elements not found.");
-  } else {
-    const button = menuButton;
-    const menu = mobileMenu;
-    const openIcon = iconOpen;
-    const closeIcon = iconClose;
-    let isOpen = false;
-    const mediaQuery = window.matchMedia("(min-width: 768px)");
-
-    const toggleMenu = () => {
-      isOpen = !isOpen;
-      menu.classList.toggle("hidden", !isOpen);
-      menu.setAttribute("aria-hidden", String(!isOpen));
-      button.setAttribute("aria-expanded", String(isOpen));
-      button.setAttribute(
-        "aria-label",
-        isOpen ? "メニューを閉じる" : "メニューを開く",
-      );
-      openIcon.classList.toggle("hidden", isOpen);
-      closeIcon.classList.toggle("hidden", !isOpen);
-    };
-
-    button.addEventListener("click", toggleMenu);
-
-    document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape" && isOpen) {
-        toggleMenu();
-        button.focus();
-      }
-    });
-
-    window.addEventListener("resize", () => {
-      if (mediaQuery.matches && isOpen) {
-        toggleMenu();
-      }
-    });
-  }
-</script>

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,0 +1,249 @@
+import { motion, useReducedMotion } from "framer-motion";
+import * as React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { NavLink } from "@/config/navigation";
+
+const ease = [0.22, 1, 0.36, 1] as const;
+const EXIT_MS = 240;
+
+type Props = {
+	links: readonly NavLink[];
+	currentPath: string;
+};
+
+function isActivePath(href: string, currentPath: string): boolean {
+	if (href === "/") return currentPath === "/";
+	return currentPath.startsWith(href);
+}
+
+export default function MobileNav({ links, currentPath }: Props) {
+	const [isOpen, setIsOpen] = useState(false);
+	const prefersReducedMotion = useReducedMotion();
+	const dialogRef = useRef<HTMLDialogElement>(null);
+	const openButtonRef = useRef<HTMLButtonElement>(null);
+	const closingRef = useRef(false);
+
+	const syncHeader = useCallback((open: boolean) => {
+		const header = document.querySelector("header");
+		if (!header) return;
+		if (open) {
+			header.setAttribute("data-menu-open", "");
+		} else {
+			header.removeAttribute("data-menu-open");
+		}
+	}, []);
+
+	const openMenu = useCallback(() => {
+		const dialog = dialogRef.current;
+		if (!dialog || dialog.open) return;
+		closingRef.current = false;
+		dialog.showModal();
+		setIsOpen(true);
+		syncHeader(true);
+	}, [syncHeader]);
+
+	const closeMenu = useCallback(() => {
+		const dialog = dialogRef.current;
+		if (!dialog?.open || closingRef.current) return;
+
+		closingRef.current = true;
+		setIsOpen(false);
+		syncHeader(false);
+
+		const delay = prefersReducedMotion ? 0 : EXIT_MS;
+		window.setTimeout(() => {
+			if (dialog.open) {
+				dialog.close();
+			}
+			closingRef.current = false;
+			openButtonRef.current?.focus();
+		}, delay);
+	}, [prefersReducedMotion, syncHeader]);
+
+	useEffect(() => {
+		const dialog = dialogRef.current;
+		if (!dialog) return;
+
+		const onCancel = (event: Event) => {
+			event.preventDefault();
+			closeMenu();
+		};
+
+		const onClose = () => {
+			setIsOpen(false);
+			syncHeader(false);
+			closingRef.current = false;
+		};
+
+		dialog.addEventListener("cancel", onCancel);
+		dialog.addEventListener("close", onClose);
+		return () => {
+			dialog.removeEventListener("cancel", onCancel);
+			dialog.removeEventListener("close", onClose);
+		};
+	}, [closeMenu, syncHeader]);
+
+	useEffect(() => {
+		const mediaQuery = window.matchMedia("(min-width: 768px)");
+		const onViewportChange = () => {
+			if (mediaQuery.matches && dialogRef.current?.open) {
+				closeMenu();
+			}
+		};
+		mediaQuery.addEventListener("change", onViewportChange);
+		return () => mediaQuery.removeEventListener("change", onViewportChange);
+	}, [closeMenu]);
+
+	useEffect(() => {
+		return () => {
+			document.querySelector("header")?.removeAttribute("data-menu-open");
+		};
+	}, []);
+
+	const listVariants = prefersReducedMotion
+		? undefined
+		: {
+				open: {
+					transition: { staggerChildren: 0.055, delayChildren: 0.04 },
+				},
+				closed: {
+					transition: { staggerChildren: 0.03, staggerDirection: -1 },
+				},
+			};
+
+	const itemVariants = prefersReducedMotion
+		? undefined
+		: {
+				open: {
+					opacity: 1,
+					x: 0,
+					transition: { duration: 0.42, ease },
+				},
+				closed: {
+					opacity: 0,
+					x: 36,
+					transition: { duration: 0.22, ease },
+				},
+			};
+
+	return (
+		<div className="md:hidden">
+			<button
+				ref={openButtonRef}
+				type="button"
+				className="flex h-10 w-10 items-center justify-center rounded-md transition-colors hover:bg-(--bg-secondary)"
+				aria-label="メニューを開く"
+				aria-haspopup="dialog"
+				aria-expanded={isOpen}
+				onClick={openMenu}
+			>
+				<svg
+					className="h-5 w-5"
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+					aria-hidden="true"
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						strokeWidth="2"
+						d="M4 6h16M4 12h16M4 18h16"
+					/>
+				</svg>
+			</button>
+
+			<dialog
+				ref={dialogRef}
+				className="mobile-nav-dialog m-0 h-dvh max-h-dvh w-full max-w-none border-0 bg-(--bg-primary) p-0 text-(--text-primary)"
+				aria-label="メニュー"
+			>
+				<div className="flex h-(--header-height) items-center justify-end px-6">
+					<button
+						type="button"
+						className="flex h-10 w-10 items-center justify-center rounded-md transition-colors hover:bg-(--bg-secondary)"
+						aria-label="メニューを閉じる"
+						onClick={closeMenu}
+					>
+						<svg
+							className="h-5 w-5"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+							aria-hidden="true"
+						>
+							<path
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								strokeWidth="2"
+								d="M6 18L18 6M6 6l12 12"
+							/>
+						</svg>
+					</button>
+				</div>
+
+				<nav aria-label="モバイルナビゲーション">
+					<motion.ul
+						className="space-y-1 px-6 py-4"
+						initial="closed"
+						animate={isOpen ? "open" : "closed"}
+						variants={listVariants}
+					>
+						{links.map((link) => {
+							const active = isActivePath(link.href, currentPath);
+							return (
+								<motion.li key={link.href} variants={itemVariants}>
+									<a
+										href={link.href}
+										aria-current={active ? "page" : undefined}
+										className={[
+											"block rounded-lg px-4 py-3 text-lg font-medium transition-colors duration-200 hover:bg-(--bg-secondary) hover:text-(--text-primary)",
+											active
+												? "font-semibold text-(--text-primary)"
+												: "text-(--text-secondary)",
+										].join(" ")}
+									>
+										{link.text}
+									</a>
+								</motion.li>
+							);
+						})}
+					</motion.ul>
+				</nav>
+			</dialog>
+
+			<style>{`
+				.mobile-nav-dialog {
+					border: none;
+					outline: none;
+					box-shadow: none;
+				}
+
+				.mobile-nav-dialog[open] {
+					display: flex;
+					flex-direction: column;
+				}
+
+				.mobile-nav-dialog::backdrop {
+					background: rgb(28 27 25 / 0.28);
+				}
+
+				@media (prefers-reduced-motion: no-preference) {
+					.mobile-nav-dialog[open]::backdrop {
+						animation: mobile-nav-backdrop-in 0.2s cubic-bezier(0.22, 1, 0.36, 1) both;
+					}
+				}
+
+				@keyframes mobile-nav-backdrop-in {
+					from {
+						opacity: 0;
+					}
+					to {
+						opacity: 1;
+					}
+				}
+			`}</style>
+		</div>
+	);
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -116,7 +116,6 @@ const books = defineCollection({
 			finishedDate: z.coerce.date().optional(),
 			rating: z.number().min(1).max(5).optional(),
 			category: z.string().optional(),
-			tags: z.array(z.string()), // Required for books
 			excerpt: excerptSchema,
 		}),
 });

--- a/src/content/books/sample-book.md
+++ b/src/content/books/sample-book.md
@@ -6,7 +6,6 @@ status: "read"
 finishedDate: 2024-06-30
 rating: 4
 category: "技術"
-tags: ["Astro", "Web", "設計"]
 excerpt: "Astroを中心に、コンテンツ設計とページ構成を学ぶための入門書。"
 ---
 

--- a/src/pages/bookshelf/[id].astro
+++ b/src/pages/bookshelf/[id].astro
@@ -20,11 +20,6 @@ const { book } = Astro.props;
 const { Content } = await render(book);
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const ogImageURL = new URL(book.data.coverImage.src, Astro.site);
-const tags = book.data.tags
-	? Array.isArray(book.data.tags)
-		? book.data.tags
-		: [book.data.tags]
-	: [];
 const bookSchema = {
 	"@context": "https://schema.org",
 	"@type": "Book",
@@ -35,7 +30,7 @@ const bookSchema = {
 	},
 	description: book.data.excerpt,
 	image: ogImageURL.href,
-	genre: tags.join(", "),
+	...(book.data.category ? { genre: book.data.category } : {}),
 	url: canonicalURL.href,
 	inLanguage: SITE.lang,
 };
@@ -50,7 +45,6 @@ const bookSchema = {
 >
   <Fragment slot="head">
     <meta property="book:author" content={book.data.author} />
-    {tags.map((tag) => <meta property="book:tag" content={tag} />)}
     <script
       type="application/ld+json"
       set:html={stringifySchema(bookSchema)}
@@ -87,9 +81,6 @@ const bookSchema = {
             </span>
           )
         }
-      </div>
-      <div class="flex flex-wrap gap-2">
-        {tags.map((tag) => <Tag>{tag}</Tag>)}
       </div>
     </div>
 

--- a/src/pages/bookshelf/index.astro
+++ b/src/pages/bookshelf/index.astro
@@ -1,7 +1,6 @@
 ---
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
-import FilterSort from "@/components/FilterSort.astro";
 import Badge from "@/components/ui/Badge.astro";
 import Tag from "@/components/ui/Tag.astro";
 import { SITE } from "@/config/site";
@@ -15,13 +14,6 @@ const sortedBooks = [...books].toSorted((a, b) => {
 	const bTime = b.data.finishedDate?.getTime() ?? 0;
 	return bTime - aTime;
 });
-
-// すべてのタグを収集（カテゴリ + タグ）
-const allTags = books.flatMap((book) => [
-	...(book.data.category ? [book.data.category] : []),
-	...book.data.tags,
-]);
-
 ---
 
 <Layout
@@ -31,23 +23,12 @@ const allTags = books.flatMap((book) => [
   <main class="mx-auto max-w-6xl px-6 py-12">
     <h1 class="mb-12 text-4xl font-bold text-(--text-primary)">Bookshelf</h1>
 
-    <FilterSort tags={allTags} containerId="bookshelf-list" />
-
-    <div id="bookshelf-list" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {
-        sortedBooks.map((book) => {
-          const bookTags = [
-            ...(book.data.category ? [book.data.category] : []),
-            ...book.data.tags,
-          ];
-          return (
+        sortedBooks.map((book) => (
           <a
             href={`/bookshelf/${book.id}`}
             class="group block overflow-hidden"
-            data-item
-            data-tags={bookTags.join(",")}
-            data-date={book.data.finishedDate?.toISOString() ?? ""}
-            data-title={book.data.title}
           >
             <div class="aspect-[3/4] overflow-hidden">
               <Image
@@ -69,9 +50,6 @@ const allTags = books.flatMap((book) => [
                 </p>
               )}
               <p class="mb-3 text-sm text-(--text-secondary)">{book.data.excerpt}</p>
-              <div class="flex flex-wrap gap-2">
-                {book.data.tags.map((tag) => <Tag>{tag}</Tag>)}
-              </div>
               {book.data.rating && (
                 <p class="mt-3 text-xs text-(--text-muted)">
                   評価: {book.data.rating} / 5
@@ -79,19 +57,8 @@ const allTags = books.flatMap((book) => [
               )}
             </div>
           </a>
-        );})
+        ))
       }
     </div>
   </main>
 </Layout>
-
-<script>
-  document.querySelectorAll("[data-filter-sort] .filter-chip").forEach((chip) => {
-    chip.addEventListener("click", () => {
-      const tag = (chip as HTMLElement).dataset.tag;
-      if (tag && tag !== "all") {
-        window.posthog?.capture("bookshelf_tag_filtered", { tag });
-      }
-    });
-  });
-</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -51,6 +51,42 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 }
 
+/* 紙のざらつき（コンテンツページのみ。トップはヒーロー側で完結）
+ * - ::before: 細かい粒子（フィルムグレイン）
+ * - ::after: 粗い繊維（紙の目） */
+body:not(.lock-viewport)::before,
+body:not(.lock-viewport)::after {
+	content: "";
+	position: fixed;
+	inset: 0;
+	z-index: 9999;
+	pointer-events: none;
+}
+
+body:not(.lock-viewport)::before {
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.95' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3CfeComponentTransfer%3E%3CfeFuncR type='linear' slope='2.4' intercept='-0.7'/%3E%3CfeFuncG type='linear' slope='2.4' intercept='-0.7'/%3E%3CfeFuncB type='linear' slope='2.4' intercept='-0.7'/%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+	background-size: 140px 140px;
+	opacity: 0.28;
+	mix-blend-mode: soft-light;
+}
+
+body:not(.lock-viewport)::after {
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='320' height='320'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='turbulence' baseFrequency='0.4' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+	background-size: 220px 220px;
+	opacity: 0.14;
+	mix-blend-mode: multiply;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	body:not(.lock-viewport)::before {
+		opacity: 0.18;
+	}
+
+	body:not(.lock-viewport)::after {
+		opacity: 0.08;
+	}
+}
+
 /* Focus */
 :focus-visible {
 	outline: 2px solid var(--primary-color);


### PR DESCRIPTION
## Summary
- モバイルナビを Framer Motion + ネイティブ `<dialog>`（`showModal`）で再実装し、項目を右から左へスタッガー表示
- コンテンツページに紙ノイズを追加（トップのヒーローは変更なし）
- Bookshelf からタグ／フィルタ UI を削除

## Test plan
- [ ] モバイル幅でハンバーガーを開き、Dialog・閉じるボタン・Escape・項目アニメーションを確認
- [ ] `/blog` などコンテンツページで紙ノイズが見えること、トップではヒーローのみであること
- [ ] `/bookshelf` にタグ・フィルタが出ないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an animated, accessible mobile navigation menu with active-link indicators and responsive behavior.
  * Added a subtle paper-texture effect to content pages, with reduced-motion support.

* **Improvements**
  * Simplified bookshelf browsing by removing tag-based filtering and tag displays.
  * Book pages now use category information instead of tags.

* **Content Updates**
  * Book entries no longer require tag metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->