### PR TITLE
style: トップ以外のヘッダー背景を不透明にする

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,10 +4,16 @@ import { NAV_LINKS } from "@/config/navigation";
 import Logo from "./Logo.astro";
 import MobileNav from "./MobileNav";
 import NavLink from "./ui/NavLink.astro";
+
+const isHome =
+	Astro.url.pathname === "/" || Astro.url.pathname === "";
 ---
 
 <header
-  class="fixed inset-x-0 top-0 z-50 bg-transparent transition-colors data-[menu-open]:bg-(--bg-primary)"
+  class:list={[
+    "fixed inset-x-0 top-0 z-50 transition-colors data-[menu-open]:bg-(--bg-primary)",
+    isHome ? "bg-transparent" : "bg-(--bg-primary)",
+  ]}
 >
   <nav
     class="relative mx-auto flex h-(--header-height) max-w-7xl items-center justify-between px-6"


### PR DESCRIPTION
## Summary
- トップ (`/`) のみヘッダー背景を透過
- それ以外のページは `--bg-primary` の不透明背景

## Test plan
- [ ] `/` でヘッダーが透過していること
- [ ] `/blog` などでヘッダーが白い不透明背景であること
- [ ] モバイルでメニューを開くと不透明になること