### PR TITLE
chore: Entire のチェックポイント保存を refs バックエンドへ切り替える

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,12 +2,8 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Task",
+        "matcher": "Agent",
         "hooks": [
-          {
-            "type": "command",
-            "command": "entire hooks claude-code post-task"
-          },
           {
             "type": "command",
             "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks claude-code post-task'"
@@ -15,12 +11,8 @@
         ]
       },
       {
-        "matcher": "TodoWrite",
+        "matcher": "TaskCreate|TaskUpdate",
         "hooks": [
-          {
-            "type": "command",
-            "command": "entire hooks claude-code post-todo"
-          },
           {
             "type": "command",
             "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks claude-code post-todo'"
@@ -30,12 +22,8 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Task",
+        "matcher": "Agent",
         "hooks": [
-          {
-            "type": "command",
-            "command": "entire hooks claude-code pre-task"
-          },
           {
             "type": "command",
             "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks claude-code pre-task'"
@@ -49,10 +37,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "entire hooks claude-code session-end"
-          },
-          {
-            "type": "command",
             "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks claude-code session-end'"
           }
         ]
@@ -62,10 +46,6 @@
       {
         "matcher": "",
         "hooks": [
-          {
-            "type": "command",
-            "command": "entire hooks claude-code session-start"
-          },
           {
             "type": "command",
             "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then printf \"%s\\n\" \"{\\\"systemMessage\\\":\\\"\\\\n\\\\nEntire CLI is enabled but not installed or not on PATH.\\\\nInstallation guide: https://docs.entire.io/cli/installation#installation-methods\\\"}\"; exit 0; fi; exec entire hooks claude-code session-start'"
@@ -79,10 +59,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "entire hooks claude-code stop"
-          },
-          {
-            "type": "command",
             "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks claude-code stop'"
           }
         ]
@@ -92,10 +68,6 @@
       {
         "matcher": "",
         "hooks": [
-          {
-            "type": "command",
-            "command": "entire hooks claude-code user-prompt-submit"
-          },
           {
             "type": "command",
             "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks claude-code user-prompt-submit'"

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,40 @@
+{
+  "hooks": {
+    "beforeSubmitPrompt": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor before-submit-prompt'"
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor pre-compact'"
+      }
+    ],
+    "sessionEnd": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-end'"
+      }
+    ],
+    "sessionStart": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-start'"
+      }
+    ],
+    "stop": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor stop'"
+      }
+    ],
+    "subagentStart": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-start'"
+      }
+    ],
+    "subagentStop": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-stop'"
+      }
+    ]
+  },
+  "version": 1
+}

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,5 +1,10 @@
 {
   "enabled": true,
   "telemetry": false,
+  "checkpoints": {
+    "primary": {
+      "type": "git-refs"
+    }
+  },
   "strategy": "manual-commit"
 }

--- a/.opencode/plugins/entire.ts
+++ b/.opencode/plugins/entire.ts
@@ -14,6 +14,9 @@ export const EntirePlugin: Plugin = async ({ directory }) => {
   let currentModel: string | null = null
   // In-memory store for message metadata (role, tokens, etc.)
   const messageStore = new Map<string, any>()
+  // One-time model-context injection captured from the turn-start hook's stdout,
+  // applied on the next LLM call via experimental.chat.system.transform.
+  let pendingInjection: string | null = null
 
   /**
    * Build the shell command for a hook invocation.
@@ -66,6 +69,46 @@ export const EntirePlugin: Plugin = async ({ directory }) => {
     }
   }
 
+  // parseInjectedContext scans a hook's stdout for Entire's injection envelope
+  // ({"inject_context":"..."}) and returns the text to inject, or null.
+  function parseInjectedContext(stdout: string): string | null {
+    if (!stdout) return null
+    for (const line of stdout.split("\n")) {
+      const trimmed = line.trim()
+      if (!trimmed.startsWith("{")) continue
+      try {
+        const parsed = JSON.parse(trimmed) as { inject_context?: unknown }
+        if (typeof parsed.inject_context === "string" && parsed.inject_context.length > 0) {
+          return parsed.inject_context
+        }
+      } catch {
+        // not our envelope — ignore
+      }
+    }
+    return null
+  }
+
+  // fireTurnStart fires turn-start synchronously (state must be ready before
+  // mid-turn commits) and stashes any model-context injection emitted on stdout
+  // for experimental.chat.system.transform to apply. Entire emits the injection
+  // at most once per session, so pendingInjection is set on the first turn only.
+  function fireTurnStart(payload: Record<string, unknown>) {
+    try {
+      const json = JSON.stringify(payload)
+      const proc = Bun.spawnSync(hookCmd("turn-start"), {
+        cwd: directory,
+        stdin: new TextEncoder().encode(json + "\n"),
+        stdout: "pipe",
+        stderr: "ignore",
+      })
+      const out = proc.stdout ? proc.stdout.toString() : ""
+      const injected = parseInjectedContext(out)
+      if (injected) pendingInjection = injected
+    } catch {
+      // Silently ignore — plugin failures must not crash OpenCode
+    }
+  }
+
   function resetSessionTracking(sessionID: string) {
     if (currentSessionID === sessionID) {
       return false
@@ -74,10 +117,21 @@ export const EntirePlugin: Plugin = async ({ directory }) => {
     messageStore.clear()
     currentModel = null
     currentSessionID = sessionID
+    // Drop any turn-start injection captured for the prior session so it
+    // can't leak into the new session's system prompt.
+    pendingInjection = null
     return true
   }
 
   return {
+    // Apply the one-time Entire context injection captured at turn-start by
+    // appending it to the system prompt for this LLM call.
+    "experimental.chat.system.transform": async (_input: unknown, output: { system: string[] }) => {
+      if (pendingInjection && Array.isArray(output.system)) {
+        output.system.push(pendingInjection)
+        pendingInjection = null
+      }
+    },
     event: async ({ event }) => {
       try {
         switch (event.type) {
@@ -124,7 +178,7 @@ export const EntirePlugin: Plugin = async ({ directory }) => {
               seenUserMessages.add(msg.id)
               const sessionID = msg.sessionID ?? currentSessionID
               if (sessionID) {
-                callHookSync("turn-start", {
+                fireTurnStart({
                   session_id: sessionID,
                   prompt: "",
                   model: currentModel ?? "",
@@ -144,7 +198,7 @@ export const EntirePlugin: Plugin = async ({ directory }) => {
               seenUserMessages.add(msg.id)
               const sessionID = msg.sessionID ?? currentSessionID
               if (sessionID) {
-                callHookSync("turn-start", {
+                fireTurnStart({
                   session_id: sessionID,
                   prompt: part.text ?? "",
                   model: currentModel ?? "",
@@ -185,6 +239,7 @@ export const EntirePlugin: Plugin = async ({ directory }) => {
             seenUserMessages.clear()
             messageStore.clear()
             currentSessionID = null
+            pendingInjection = null
             // Use sync variant: session-end may fire during shutdown.
             callHookSync("session-end", {
               session_id: session.id,
@@ -201,6 +256,7 @@ export const EntirePlugin: Plugin = async ({ directory }) => {
             seenUserMessages.clear()
             messageStore.clear()
             currentSessionID = null
+            pendingInjection = null
             // Use sync variant: this is the last event before process exit.
             callHookSync("session-end", {
               session_id: sessionID,

--- a/.pi/extensions/entire/index.ts
+++ b/.pi/extensions/entire/index.ts
@@ -11,24 +11,57 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { execFile } from "node:child_process";
 
 export default function (pi: ExtensionAPI) {
-  const ENTIRE_CMD = "entire";
+  // A Pi subagent is a nested `pi` process (subagent extensions spawn one per task
+  // with cwd inside the project, where Pi auto-discovers this same project-local
+  // extension), so it would otherwise forward its own lifecycle as the user's
+  // session. Mark this process so any Pi it spawns knows it is nested.
+  //
+  // WARNING: Entire's own hook subprocesses inherit this marker from the parent, so
+  // the CLI side must never treat it as a skip signal — it would disable tracking
+  // for everyone. See docs/architecture/agent-guide.md.
+  const nested = Boolean(process.env.ENTIRE_PI_NESTED);
+  process.env.ENTIRE_PI_NESTED = "1";
+
+  const ENTIRE_CMD = 'entire';
   let pendingSkillEvents: Array<{ skill_name: string; invocation: string; timestamp: string }> = [];
 
-  function fireHook(hookName: string, data: Record<string, unknown>): Promise<void> {
+  // fireHook pipes data to `entire hooks pi <hookName>` and resolves with the
+  // hook's stdout (empty string on any failure). Most hooks ignore the return;
+  // before_agent_start uses it to apply a model-context injection.
+  function fireHook(hookName: string, data: Record<string, unknown>): Promise<string> {
     return new Promise((resolve) => {
       try {
         const child = execFile(
           "sh",
           ["-c", `${ENTIRE_CMD} hooks pi ${hookName}`],
-          { timeout: 10000, windowsHide: true },
-          () => resolve(),
+          { timeout: 10000, windowsHide: true, maxBuffer: 4 * 1024 * 1024 },
+          (_err, stdout) => resolve(typeof stdout === "string" ? stdout : ""),
         );
         child.stdin?.end(JSON.stringify(data));
       } catch {
         // best effort — never block the agent on a hook failure
-        resolve();
+        resolve("");
       }
     });
+  }
+
+  // parseInjectedContext scans a hook's stdout for Entire's injection envelope
+  // ({"inject_context":"..."}) and returns the text to inject, or null.
+  function parseInjectedContext(stdout: string): string | null {
+    if (!stdout) return null;
+    for (const line of stdout.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("{")) continue;
+      try {
+        const parsed = JSON.parse(trimmed) as { inject_context?: unknown };
+        if (typeof parsed.inject_context === "string" && parsed.inject_context.length > 0) {
+          return parsed.inject_context;
+        }
+      } catch {
+        // not our envelope — ignore
+      }
+    }
+    return null;
   }
 
   function parseSkillInvocation(text: string): { skill_name: string; invocation: string } | null {
@@ -38,17 +71,14 @@ export default function (pi: ExtensionAPI) {
     return { skill_name: match[1], invocation };
   }
 
-  pi.on("input", async (event) => {
-    const skill = parseSkillInvocation(event.text);
-    if (skill) {
-      pendingSkillEvents.push({ ...skill, timestamp: new Date().toISOString() });
-    }
-    return { action: "continue" };
-  });
-
   // Agent-driven bash subprocesses inherit a real TTY but cannot answer
   // hook prompts. Disable git/Entire terminal prompts for bash calls so
   // Entire treats agent-driven commits as non-interactive.
+  //
+  // Registered even when nested: a nested Pi is non-interactive by construction
+  // while still inheriting the parent's TTY, and Entire's git hooks live in
+  // .git/hooks independently of this extension, so a nested subagent that commits
+  // needs this hardening at least as much as the parent does.
   pi.on("tool_call", async (event) => {
     if (event.toolName !== "bash") return;
     const input = event.input as { command?: string };
@@ -56,6 +86,18 @@ export default function (pi: ExtensionAPI) {
       return;
     }
     input.command = "export GIT_TERMINAL_PROMPT=0\n" + input.command;
+  });
+
+  // Everything below forwards session lifecycle to Entire, which only the
+  // top-level Pi may do.
+  if (nested) return;
+
+  pi.on("input", async (event) => {
+    const skill = parseSkillInvocation(event.text);
+    if (skill) {
+      pendingSkillEvents.push({ ...skill, timestamp: new Date().toISOString() });
+    }
+    return { action: "continue" };
   });
 
   pi.on("session_start", async (_event, ctx) => {
@@ -69,13 +111,26 @@ export default function (pi: ExtensionAPI) {
   pi.on("before_agent_start", async (event, ctx) => {
     const skillEvents = pendingSkillEvents;
     pendingSkillEvents = [];
-    await fireHook("before_agent_start", {
+    const stdout = await fireHook("before_agent_start", {
       type: "before_agent_start",
       cwd: ctx.cwd,
       session_file: ctx.sessionManager.getSessionFile(),
       prompt: event.prompt,
       skill_events: skillEvents,
     });
+    const injected = parseInjectedContext(stdout);
+    if (injected) {
+      // Inject a hidden, persistent message so the model learns about Entire.
+      // display:false keeps it out of the user-facing transcript while still
+      // sending it to the LLM. Entire emits this at most once per session.
+      return {
+        message: {
+          customType: "entire-context",
+          content: injected,
+          display: false,
+        },
+      };
+    }
   });
 
   pi.on("agent_end", async (_event, ctx) => {


### PR DESCRIPTION
## 概要

Entire のチェックポイント保存を、共有ブランチ方式（`entire/checkpoints/v1`）から **refs バックエンド**（チェックポイント 1 件ごとに `refs/entire/checkpoints/<shard>/<id>`）へ切り替えます。あわせてエージェントフックを最新化しました。

## 変更内容

### 1. チェックポイントバックエンドの切り替え (`fd2045c`)

`.entire/settings.json` に `checkpoints.primary.type: "git-refs"` を追加。

| | branch（従来） | refs（今回） |
|---|---|---|
| 保存先 | 共有ブランチ `entire/checkpoints/v1` | `refs/entire/checkpoints/<shard>/<id>` |
| Checkpoint ID | 12 桁 hex | 26 桁 ULID（時系列ソート可） |

push / fetch がチェックポイント単位で独立するため履歴の増加に強く、複数エージェントが同時にチェックポイントを保存してもブランチ更新が競合しません。

既存 36 件は `entire doctor migrate-checkpoints` で refs 形式へ変換済み（origin にも同期済み、計 38 refs）。旧ブランチ `entire/checkpoints/v1` は削除せず残しています — 公式ドキュメント上、旧チェックポイントは refs 側と併存して参照可能です。

### 2. エージェントフックの更新 (`21c8b12`)

`entire enable --force` による再生成。

- Claude Code の matcher が現行のツール名に追随（`Task` → `Agent`、`TodoWrite` → `TaskCreate|TaskUpdate`）
- `entire` 未インストール時に無害終了するガード付きコマンドへ一本化
- OpenCode / Pi の拡張を最新版へ更新
- 新たに Cursor のフック定義（`.cursor/hooks.json`）を追加

## 検証

- `entire checkpoint explain c85b407d5101` で移行済みチェックポイントが refs バックエンド経由で読めることを確認
- 切り替え後の新規チェックポイントが ULID (`01M09T1P5J47PKTM4ZVB4QK2C2`) として `refs/entire/checkpoints/` 配下に作成されることを確認
- `entire status` の未同期・フック警告がすべて解消
- アプリケーションコードの変更はないため、ビルド・テストへの影響はありません

## 補足（ハマりどころ）

`entire doctor migrate-checkpoints` は **branch が primary の間にしか動作しません**。先に refs へ切り替えると `nothing to migrate` となり空振りします。正しい順序は「移行 → バックエンド切り替え」です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7wEXEArCQf1So6bedgZn5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ta93abe/me/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for lifecycle integration with Cursor, OpenCode, and Pi.
  - Added configurable project checkpoints using Git references.
  - Preserved relevant session context across supported assistant interactions.

- **Bug Fixes**
  - Improved behavior when the command-line tool is unavailable, allowing workflows to complete without errors.
  - Improved handling of nested sessions and subprocesses to prevent duplicate lifecycle activity.
  - Increased reliability of session startup, shutdown, and context injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->